### PR TITLE
Refactors analytics index page

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -8,10 +8,15 @@ class AnalyticsController < ApplicationController
   def index
     @last_days = 30
     @full_width_content = true
-    @visits = Visit.this_month
-    @users = User.where(created_at: @last_days.days.ago..Time.now)
+    @visits_this_month = Visit.this_month
+    @visits_today = Visit.today
+    @users_this_month = User.this_month
     @views = Ahoy::Event.where(name: '$view')
     @articles = Article.this_month
+    @most_recent_articles = Article.most_recent 10
+    @most_followed_articles = Article.most_followers 10
+    @most_visited_articles = DetermineVisitsToArticles.call(Visit.most_popular(13))
+    @most_commented_articles = Article.most_commented 10
   end
 
   private
@@ -22,4 +27,6 @@ class AnalyticsController < ApplicationController
     return if current_user.admin? || current_user.analyst?
     redirect_to root_url # or whatever
   end
+
+  
 end

--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -1,4 +1,33 @@
 # frozen_string_literal: true
 
 module AnalyticsHelper
+  def metric_by_day(data, metric)
+    case metric
+    when :visits
+      data.group_by_day(:started_at).count
+    when :users
+      data.group_by_day(:created_at).count
+    end
+  end
+
+  def metric_grouped_by_category(data, category)
+    data.group(category).count
+  end
+
+  def metric_grouped_by_category_in_descending_order(data, category, limit)
+    data.group(category).order('count_id DESC').limit(limit).count(:id)
+  end
+
+  def link_to_article_title(article, length)
+    link_to truncate(aricle.title, length: length), article
+  end
+
+  def link_to_article_follower_count(article)
+    link_to article.follows_count, articles_followers_path(article)
+  end
+
+  def article_updated_at(article)
+    article.updated_at.strftime("%m.%e, %l:%M %p")
+  end
+  
 end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -59,6 +59,9 @@ class Article < ActiveRecord::Base
   scope :by_state, ->(state_id) { where(state_id: state_id) }
   scope :this_month, -> { where(created_at: 30.days.ago..Date.today) }
   scope :property_count_over_time, ->(property, days) { where("#{property}": days.to_s.to_i.days.ago..Time.now).count }
+  scope :most_recent, -> (limit) { order("updated_at desc").limit(limit) }
+  scope :most_followers, -> (limit) { order(follows_count: :desc).limit(limit) }
+  scope :most_commented, -> (limit) { order(comments_count: :desc).limit(limit) }
 
   def full_address
     "#{address} #{city} #{state.ansi_code} #{zipcode}".strip

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -16,6 +16,9 @@ class User < ActiveRecord::Base
   acts_as_messageable
   extend FriendlyId
   friendly_id :slug_candidates, use: %i[slugged finders]
+
+  #Scopes
+  scope :this_month, -> { where(created_at: 30.days.ago..Date.today) }
   
   def mailboxer_name
     name

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -5,7 +5,9 @@ class Visit < ActiveRecord::Base
   belongs_to :user
 
   scope :this_month, -> { where(started_at: 30.days.ago..Date.today) }
+  scope :today, -> { where(started_at: 1.days.ago..Date.today) }
   scope :property_count_over_time, ->(property, days) { where("#{property}": days.to_s.to_i.days.ago..Time.now).count }
+  scope :most_popular, -> (limit) { where(started_at: 7.days.ago..Date.today).group(:landing_page).order('count_id DESC').limit(limit).count(:id)}
 
   def mom_visits_growth
     last_month_visits = Visit.property_count_over_time('started_at', 30)
@@ -14,4 +16,5 @@ class Visit < ActiveRecord::Base
 
     (((last_month_visits.to_f / prior_30_days_visits) - 1) * 100).round(2)
   end
+
 end

--- a/app/services/determine_visits_to_articles.rb
+++ b/app/services/determine_visits_to_articles.rb
@@ -1,0 +1,14 @@
+class DetermineVisitsToArticles
+  include Service
+
+  def call(visits)
+    articles = []
+    visits.each do |visits_info|
+      url = visits_info[0]
+      views = visits_info[1]
+      article = Article.friendly.find(url.split('/').last)
+      articles << [article, views] if article.exists?
+    end
+    articles
+  end
+end

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -9,7 +9,7 @@
           Visits by Day - Last <%= @last_days %> days
         </div>
         <div class="chart-stage">
-          <%= column_chart @visits.group_by_day(:started_at).count %>
+          <%= column_chart metric_by_day(@visits_this_month, :visits) %>
         </div>
         <div class="chart-notes">
           Column heights represent the number of visitors on a specific day.
@@ -20,10 +20,10 @@
     <div class="col-sm-5">
       <div class="chart-wrapper">
         <div class="chart-title background-gray">
-          Visits by browser - last 24 hours
+          Visits by Browser - last 24 hours
         </div>
         <div class="chart-stage">
-          <div id=""><%= pie_chart @visits.where(started_at: 1.days.ago..Time.now).group(:browser).count %></div>
+          <div id=""><%= pie_chart metric_grouped_by_category(@visits_today, :browser) %></div>
         </div>
         <div class="chart-notes">
           Notes go down here
@@ -37,10 +37,10 @@
     <div class="col-sm-7">
       <div class="chart-wrapper">
         <div class="chart-title background-gray">
-          New Users by Day - Last <%= @last_days %> days (<%= @users.count %>)
+          New Users by Day - Last <%= @last_days %> days (<%= @users_this_month.count %>)
         </div>
         <div class="chart-stage">
-          <%= column_chart @users.group_by_day(:created_at).count %>
+          <%= column_chart metric_by_day(@users_this_month, :users) %>
         </div>
         <div class="chart-notes">
           Column heights represent the number of users added each day.
@@ -54,7 +54,7 @@
           Referring Domains - last 24 hours
         </div>
         <div class="chart-stage">
-          <div id=""><%= pie_chart @visits.where(started_at: 1.day.ago..Time.now).group(:referring_domain).count %></div>
+          <div id=""><%= pie_chart metric_grouped_by_category(@visits_today, :referring_domain) %></div>
         </div>
         <div class="chart-notes">
           These domains are where traffic has originated
@@ -73,16 +73,14 @@
         <div class="chart-stage">
          <table class='table leader-list'>
            <tr>
-            <th></th>
             <th>Case</th>
             <th>Updated</th>
            </tr>
 
-           <% Article.order(updated_at: :desc).first(10).each_with_index do |article, i| %>
+           <% @most_recent_articles.each do |article| %>
              <tr>
-               <td><%= i + 1 %></td>
-               <td><%= link_to truncate(article.title, length: 14), article %></td>
-               <td><small><%= article.updated_at.strftime("%m.%e, %l:%M %p") %></small></td>
+               <td><%= link_to_article_title(article, 25) %></td>
+               <td><small><%= article_updated_at(article) %></small></td>
              </tr>
            <% end %>
          </table>
@@ -102,16 +100,14 @@
         <div class="chart-stage">
          <table class='table leader-list'>
            <tr>
-            <th></th>
             <th>Case</th>
             <th>Followers</th>
            </tr>
 
-           <% Article.order(follows_count: :desc).first(10).each_with_index do |article, i| %>
+           <% @most_followed_articles.each do |article| %>
              <tr>
-               <td><%= i + 1 %></td>
-               <td><%= link_to truncate(article.title, length: 25), article %></td>
-               <td><%= link_to article.follows_count, articles_followers_path(article) %></td>
+               <td><%= link_to_article_title(article, 25) %></td>
+               <td><%= link_to_article_follower_count(article) %></td>
              </tr>
            <% end %>
          </table>
@@ -124,23 +120,21 @@
     <div class="col-sm-4">
       <div class="chart-wrapper">
         <div class="chart-title background-gray">
-          Most Viewed by New Visitors - Last 7 days <%= image_tag('help_icon.png', data: {:toggle => 'popover', :container => 'body', :trigger => 'hover',:placement => "bottom", :title => "Cases Viewed By New Visitors", :content => "This metric shows the number of new visitors landing on specific EBWiki cases."})%>
+          Most Visited Articles - Last 7 days <%= image_tag('help_icon.png', data: {:toggle => 'popover', :container => 'body', :trigger => 'hover',:placement => "bottom", :title => "Cases Viewed By Visitors", :content => "This metric shows the number of visitors landing on specific EBWiki cases."})%>
         </div>
         <div class="chart-stage">
          <table class='table leader-list'>
            <tr>
-            <th></th>
             <th>Page</th>
             <th>Views</th>
            </tr>
 
-           <% Visit.where(started_at: 7.days.ago..Time.now).group(:landing_page).order('count_id DESC').limit(13).count(:id).each_with_index do |visit, i| %>
+           <% @most_visited_articles.each do |article_info| %>
+            <% article = article_info[0] %>
+            <% views = article_info[1] %>
             <tr>
-              <% if Article.find_by_slug(visit[0].split('/').last).present? %>
-                <td><%= i %></td>
-                <td><%= link_to truncate(Article.find_by_slug(visit[0].split('/').last).title, length: 25), article_path(Article.find_by_slug(visit[0].split('/').last)) %></td>
-                <td><%= visit[1] %></td>
-              <% end %>
+              <td><%= link_to_article_title(article, 25) %></td>
+              <td><%= views %></td>
             </tr>
            <% end %>
          </table>
@@ -158,19 +152,25 @@
     <div class="col-sm-12">
       <div class="chart-wrapper">
         <div class="chart-title background-orange">
-          Recent Comments
+          Most Commented Articles
         </div>
-        <ul class="scroller">
-          <% Comment.order(created_at: :desc).each do |comment| %>
-            <li>
-              <blockquote class="blockquote">
-                <p><%= link_to truncate(Article.find(comment.commentable_id).title, length: 30), article_path(Article.find(comment.commentable_id)) %> -- <%= comment.created_at.strftime("%B %d, %Y") %></p>
-                <p><%= link_to truncate(comment.content, length: 100), article_path(Article.find(comment.commentable_id)) %></p>
-                <small><%= link_to User.find(comment.user_id).name, user_path(User.find(comment.user_id)) %></small>
-              </blockquote>
-            </li>
-          <% end %>
-        </ul>
+        <div class="chart-stage">
+          <table class='table leader-list'>
+            <tr>
+              <th>Case</th>
+              <th>Number of Comments</th>
+            </tr>
+
+            <% @most_commented_articles.each do |article_info| %>
+              <% article = article_info[0] %>
+              <% comments = article_info[1] %>
+              <tr>
+                <td><%= link_to_article_title(article, 25) %></td>
+                <td><%= comments %></td>
+              </tr>
+            <% end %>
+          </table>
+        </div>
       </div>
     </div>
   </div>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -54,6 +54,13 @@ ActiveRecord::Schema.define(version: 20170919051847) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "article_documents", force: :cascade do |t|
+    t.integer  "article_id"
+    t.integer  "document_id"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
+
   create_table "article_officers", force: :cascade do |t|
     t.integer  "article_id"
     t.integer  "officer_id"
@@ -108,6 +115,13 @@ ActiveRecord::Schema.define(version: 20170919051847) do
   end
 
   add_index "comments", ["commentable_id", "commentable_type"], name: "index_comments_on_commentable_id_and_commentable_type", using: :btree
+
+  create_table "documents", force: :cascade do |t|
+    t.string   "title"
+    t.string   "attachment"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "ethnicities", force: :cascade do |t|
     t.string   "title"
@@ -263,6 +277,7 @@ ActiveRecord::Schema.define(version: 20170919051847) do
     t.boolean  "admin",                  default: false
     t.float    "latitude"
     t.float    "longitude"
+    t.string   "storytime_name"
     t.string   "name"
     t.text     "description"
     t.integer  "state_id"


### PR DESCRIPTION
This PR refactors the analytics index page by moving logic from the view to a helper, and adding scopes and service objects to reduce logic and queries.  Noe that there are no tests for the helpers due to the fact that all of the added methods are merely wrappers for Rails and Ruby methods.

Note that, even using a database dump, it is not possible to view the page in question locally due to the lack of data.  We'll have to proof this in staging.

This PR addresses Issue #918 