### PR TITLE
Refactors agency factory.

### DIFF
--- a/spec/factories/agencies.rb
+++ b/spec/factories/agencies.rb
@@ -3,15 +3,7 @@
 FactoryBot.define do
   factory :agency do |f|
     f.sequence(:name) { |n| "#{n}_Agency" }
-    f.street_address '230 West 43rd St.'
-    f.city 'New York City'
     f.state
-    f.zipcode '10036'
-    f.description 'MyText'
-    f.telephone 'MyString'
-    f.email 'MyString'
-    f.website 'MyString'
-    f.lead_officer 'MyString'
   end
 
   factory :invalid_agency, class: Agency do |f|

--- a/spec/helpers/agencies_helper_spec.rb
+++ b/spec/helpers/agencies_helper_spec.rb
@@ -1,7 +1,12 @@
 require "rails_helper"
 
 RSpec.describe AgenciesHelper, :type => :helper do
-  let(:agency) { FactoryBot.create(:agency, name: 'Spec_Agency') }
+
+  before(:each) do
+    @texas = FactoryBot.create(:state_texas)
+  end
+
+  let(:agency) { FactoryBot.create(:agency, name: 'Spec_Agency', state_id: @texas.id) }
 
   describe "#link_to_name" do
     it "displays formatted agency name" do

--- a/spec/support/geocoder.rb
+++ b/spec/support/geocoder.rb
@@ -90,6 +90,16 @@ addresses = {
     'country' => 'United States',
     'country_code' => 'US'
   },
+  'TX' => {
+    'latitude' => 29.787849,
+    'longitude' => -100.4530357,
+    'address' => 'Austin, TX',
+    'city' => 'Austin',
+    'state' => 'Texas',
+    'state_code' => 'TX',
+    'country' => 'United States',
+    'country_code' => 'US'
+  },
   'Baton Rouge LA' => {
     'latitude' => 30.4416952,
     'longitude' => -91.2515061,


### PR DESCRIPTION
Refactors the agency factory to use the least amount of data possible for creation.  This should speed up tests over time, especially once the state factory becomes a fixture file.  Also replaces usage of the agency factory with `Agency.new` where possible, again speeding up tests.