### PR TITLE
Adds specs for article scopes

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -57,7 +57,7 @@ class Article < ActiveRecord::Base
   end
   # Scopes
   scope :by_state, ->(state_id) { where(state_id: state_id) }
-  scope :this_month, -> { where(created_at: 30.days.ago..Date.today) }
+  scope :this_month, -> { where(created_at: 1.month.ago.beginning_of_day..Date.today.end_of_day) }
   scope :property_count_over_time, ->(property, days) { where("#{property}": days.to_s.to_i.days.ago..Time.now).count }
 
   def full_address

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -221,4 +221,49 @@ RSpec.describe Article, type: :model, versioning: true do
       expect(article.default_avatar_url).to_not be_nil
     end
   end
+
+  describe 'scopes' do
+    it 'returns articles by state' do
+      new_york = FactoryBot.create(:state)
+      texas = FactoryBot.create(:state_texas)
+
+      tx_article_one = FactoryBot.create(:article,
+                                        city: 'Houston',
+                                        state_id: texas.id)
+      tx_article_two = FactoryBot.create(:article,
+                                        city: 'Dallas',
+                                        state_id: texas.id)
+      ny_article = FactoryBot.create(:article,
+                                    city: 'Buffalo',
+                                    state_id: new_york.id)
+
+      texas_articles = Article.by_state(texas.id)
+      expect(texas_articles.count).to eq 2
+      expect(texas_articles.to_a).not_to include(ny_article)
+    end
+
+    it 'returns articles created in the past month' do
+      dc = FactoryBot.create(:state_dc)
+      louisiana = FactoryBot.create(:state_louisiana)
+      texas = FactoryBot.create(:state_texas)
+
+      texas_article = FactoryBot.create(:article,
+                                       city: 'Houston',
+                                       state_id: texas.id,
+                                       created_at: Date.today)
+      louisiana_article = FactoryBot.create(:article,
+                                            city: 'Baton Rouge',
+                                            state_id: louisiana.id,
+                                            created_at: 5.weeks.ago)
+      dc_article = FactoryBot.create(:article,
+                                     city: 'Washington',
+                                     state_id: dc.id,
+                                     created_at: 1.year.ago)
+
+      recent_article = Article.this_month
+      expect(recent_article.count).to eq 1
+      expect(recent_article.to_a).not_to include(louisiana_article)
+      expect(recent_article.to_a).not_to include(dc_article)
+    end
+  end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -2,212 +2,223 @@
 
 require 'rails_helper'
 
-describe Article, versioning: true do
-  it 'is invalid without a date' do
-    article = build(:article, date: nil)
-    expect(article).to be_invalid
+RSpec.describe Article, type: :model, versioning: true do
+
+  describe "validity" do
+    it 'is invalid without a date' do
+      article = build(:article, date: nil)
+      expect(article).to be_invalid
+    end
+
+    it 'is invalid without a state_id' do
+      article = build(:article, state_id: nil)
+      article.stub(:full_address).and_return(' Albany NY ')
+      expect(article).to be_invalid
+    end
+
+    it 'is invalid without a subject' do
+      article = create(:article)
+      article.subjects = []
+      expect(article).to be_invalid
+    end
+
+    it 'is invalid without a summary' do
+      article = build(:article, summary: nil)
+      expect(article).to be_invalid
+    end
   end
 
-  it 'is invalid without a state_id' do
-    article = build(:article, state_id: nil)
-    article.stub(:full_address).and_return(' Albany NY ')
-    expect(article).to be_invalid
+  describe "versioning" do
+    it 'starts versioning when a new article is created' do
+      article = FactoryBot.create(:article)
+      expect(article.versions.size).to eq 1
+      expect(article.versions[0].event).to eq 'create'
+    end
+
+    it 'adds a version when the title is changed' do
+      article = FactoryBot.create(:article)
+      article.update_attribute(:title, 'A New Title')
+      expect(article.versions.size).to eq 2
+    end
+
+    it 'adds a version when the overview is changed' do
+      article = FactoryBot.create(:article)
+      article.update_attribute(:overview, 'An Old Article')
+      expect(article.versions.size).to eq 2
+    end
+
+    it 'adds a version when the date is changed' do
+      article = FactoryBot.create(:article)
+      article.update_attribute(:date, Date.yesterday)
+      expect(article.versions.size).to eq 2
+    end
+
+    it 'adds a version when the city is changed' do
+      article = FactoryBot.create(:article)
+      article.update_attribute(:city, 'Buffalo')
+      expect(article.versions.size).to eq 2
+    end
+
+    it 'adds a version when the avatar is changed' do
+      article = FactoryBot.create(:article)
+      article.update_attribute(:avatar, 'new_avatar')
+      expect(article.versions.size).to eq 2
+    end
+
+    it 'adds a version when the video url is changed' do
+      article = FactoryBot.create(:article)
+      article.update_attribute(:video_url, 'new_video.com')
+      expect(article.versions.size).to eq 2
+    end
+
+    it 'adds a version when the slug is changed' do
+      article = FactoryBot.create(:article)
+      article.update_attribute(:slug, 'joel-osteen')
+      expect(article.versions.size).to eq 2
+    end
+
+    it 'does not add a version when the attribute is the same' do
+      article = FactoryBot.create(:article, title: 'The Title')
+      article.update_attribute(:title, 'The Title')
+      expect(article.versions.size).to eq 1
+    end
+
+    it 'copies the article.summary attribute to version.comment' do
+      article = FactoryBot.create(:article, title: 'The Title')
+      article.update_attributes(title: 'The Title has changed', summary: 'fixed the title')
+      expect(article.versions.last.comment).to eq 'fixed the title'
+    end
   end
 
-  it 'is invalid without a subject' do
-    article = create(:article)
-    article.subjects = []
-    expect(article).to be_invalid
+  describe "slugs" do
+    it 'adds city to slug to maintain uniqueness' do
+      article = FactoryBot.create(:article, title: 'The Title')
+      article2 = FactoryBot.create(:article, title: 'The Title')
+      expect(article2.slug).to eq 'the-title-albany'
+      expect(article.slug).not_to eq article2.slug
+    end
+
+    it 'updates slug if article title is updated' do
+      article = FactoryBot.create(:article, title: 'The Title')
+      article.slug = nil
+      article.title = 'Another Title'
+      article.save!
+      article.reload
+      expect(article.slug).to eq 'another-title'
+    end
   end
 
-  it 'is invalid without a summary' do
-    article = build(:article, summary: nil)
-    expect(article).to be_invalid
+  describe '#new' do
+    it 'takes three parameters and returns an Article object' do
+      article = build(:article)
+      expect(article).to be_an_instance_of Article
+    end
   end
 
-  it 'starts versioning when a new article is created' do
-    article = FactoryBot.create(:article)
-    expect(article.versions.size).to eq 1
-    expect(article.versions[0].event).to eq 'create'
-  end
-  it 'adds a version when the title is changed' do
-    article = FactoryBot.create(:article)
-    article.update_attribute(:title, 'A New Title')
-    expect(article.versions.size).to eq 2
-  end
-  it 'adds a version when the overview is changed' do
-    article = FactoryBot.create(:article)
-    article.update_attribute(:overview, 'An Old Article')
-    expect(article.versions.size).to eq 2
-  end
-  it 'adds a version when the date is changed' do
-    article = FactoryBot.create(:article)
-    article.update_attribute(:date, Date.yesterday)
-    expect(article.versions.size).to eq 2
-  end
-  it 'adds a version when the city is changed' do
-    article = FactoryBot.create(:article)
-    article.update_attribute(:city, 'Buffalo')
-    expect(article.versions.size).to eq 2
-  end
-  it 'adds a version when the avatar is changed' do
-    article = FactoryBot.create(:article)
-    article.update_attribute(:avatar, 'new_avatar')
-    expect(article.versions.size).to eq 2
-  end
-  it 'adds a version when the video url is changed' do
-    article = FactoryBot.create(:article)
-    article.update_attribute(:video_url, 'new_video.com')
-    expect(article.versions.size).to eq 2
-  end
-  it 'adds a version when the slug is changed' do
-    article = FactoryBot.create(:article)
-    article.update_attribute(:slug, 'joel-osteen')
-    expect(article.versions.size).to eq 2
-  end
-  it 'does not add a version when the attribute is the same' do
-    article = FactoryBot.create(:article, title: 'The Title')
-    article.update_attribute(:title, 'The Title')
-    expect(article.versions.size).to eq 1
-  end
-  it 'copies the article.summary attribute to version.comment' do
-    article = FactoryBot.create(:article, title: 'The Title')
-    article.update_attributes(title: 'The Title has changed', summary: 'fixed the title')
-    expect(article.versions.last.comment).to eq 'fixed the title'
+  describe '#title' do
+    it 'returns the correct title' do
+      article = build(:article)
+      expect(article.title).to include 'Title'
+    end
   end
 
-  it 'adds city to slug to maintain uniqueness' do
-    article = FactoryBot.create(:article, title: 'The Title')
-    article2 = FactoryBot.create(:article, title: 'The Title')
-    expect(article2.slug).to eq 'the-title-albany'
-    expect(article.slug).not_to eq article2.slug
+  describe 'follower_count' do
+    it 'gives the correct followers count' do
+      article = FactoryBot.create(:article, id: 10)
+      FactoryBot.create(:follow, followable_id: 10)
+      expect(article.followers.count).to eq(1)
+    end
+
+    it 'has a zero counter cache to start' do
+      article = FactoryBot.create(:article)
+      expect(Article.last.follows_count).to eq(0)
+    end
+
+    it 'has a counter cache' do
+      article = FactoryBot.create(:article)
+      expect do
+        article.follows.create(follower_id: 1, followable_id: article.id, followable_type: 'Article', follower_type: 'User')
+      end.to change { article.reload.follows_count }.by(1)
+    end
   end
 
-  it 'updates slug if article title is updated' do
-    article = FactoryBot.create(:article, title: 'The Title')
-    article.slug = nil
-    article.title = 'Another Title'
-    article.save!
-    article.reload
-    expect(article.slug).to eq 'another-title'
-  end
-end
-
-describe '#new' do
-  it 'takes three parameters and returns an Article object' do
-    article = build(:article)
-    expect(article).to be_an_instance_of Article
-  end
-end
-
-describe '#title' do
-  it 'returns the correct title' do
-    article = build(:article)
-    expect(article.title).to include 'Title'
-  end
-end
-
-describe 'follower_count' do
-  it 'gives the correct followers count' do
-    article = FactoryBot.create(:article, id: 10)
-    FactoryBot.create(:follow, followable_id: 10)
-    expect(article.followers.count).to eq(1)
-  end
-  it 'has a zero counter cache to start' do
-    article = FactoryBot.create(:article)
-    expect(Article.last.follows_count).to eq(0)
-  end
-  it 'has a counter cache' do
-    article = FactoryBot.create(:article)
-    expect do
-      article.follows.create(follower_id: 1, followable_id: article.id, followable_type: 'Article', follower_type: 'User')
-    end.to change { article.reload.follows_count }.by(1)
-  end
-end
-
-describe '#content' do
-  it 'returns the correct content' do
-    article = build(:article)
-    expect(article.overview).to eq 'A new article'
-  end
-end
-
-describe 'geocoded' do
-  it 'generates longitude and latitude from city and state on save' do
-    article = FactoryBot.create(:article)
-    expect(article.latitude).to be_a(Float)
-    expect(article.longitude).to be_a(Float)
+  describe '#content' do
+    it 'returns the correct content' do
+      article = build(:article)
+      expect(article.overview).to eq 'A new article'
+    end
   end
 
-  it 'updates geocoded coordinates when relevant fields are updated' do
-    article = FactoryBot.create(:article)
-    ohio = FactoryBot.create(:state_ohio)
+  describe 'geocoded' do
+    it 'generates longitude and latitude from city and state on save' do
+      article = FactoryBot.create(:article)
+      expect(article.latitude).to be_a(Float)
+      expect(article.longitude).to be_a(Float)
+    end
 
-    expect do
-      article.update_attributes(city: 'Worthington',
-                                state_id: ohio.id,
-                                address: '1867 Irving Road',
-                                zipcode: '43085')
-    end.to change { article.latitude }
+    it 'updates geocoded coordinates when relevant fields are updated' do
+      article = FactoryBot.create(:article)
+      ohio = FactoryBot.create(:state_ohio)
+
+      expect do
+        article.update_attributes(city: 'Worthington',
+                                  state_id: ohio.id,
+                                  address: '1867 Irving Road',
+                                  zipcode: '43085')
+      end.to change { article.latitude }
+    end
   end
-end
 
-describe '#nearby_cases' do
-  describe 'on success' do
+  describe '#nearby_cases' do
     it 'returns an empty array if no cases are nearby' do
       article = FactoryBot.create(:article)
       expect(article.nearby_cases).to be_empty
     end
-  end
-  describe 'on failure' do
+
     it 'does not raise an error if the nearbys method returns nil' do
       article = FactoryBot.create(:article)
       allow(article).to receive(:nearbys).and_return(nil)
       expect { article.nearby_cases }.not_to raise_error
     end
   end
-end
 
-describe 'recently updated cases' do
-  it 'returns only cases updated in past 30 days' do
-    article = FactoryBot.create(:article, updated_at: 31.days.ago)
-    article2 = FactoryBot.create(:article)
-    article2.update_attribute(:video_url, 'new_video.com')
-    expect(Article.first.cases_updated_last_30_days).to eq(1)
+  describe 'recently updated cases' do
+    it 'returns only cases updated in past 30 days' do
+      article = FactoryBot.create(:article, updated_at: 31.days.ago)
+      article2 = FactoryBot.create(:article)
+      article2.update_attribute(:video_url, 'new_video.com')
+      expect(Article.first.cases_updated_last_30_days).to eq(1)
+    end
   end
-end
 
-describe 'growth_in_case_updates' do
-  it 'returns correct percentage increase' do
-    article = FactoryBot.create(:article, updated_at: 31.days.ago)
-    article2 = FactoryBot.create(:article)
-    article3 = FactoryBot.create(:article, updated_at: 10.days.ago)
-    article2.update_attribute(:video_url, 'new_video.com')
-    expect(Article.first.mom_growth_in_case_updates).to eq(100)
+  describe 'growth' do
+    it 'returns correct percentage increase for growth_in_case_updates' do
+      article = FactoryBot.create(:article, updated_at: 31.days.ago)
+      article2 = FactoryBot.create(:article)
+      article3 = FactoryBot.create(:article, updated_at: 10.days.ago)
+      article2.update_attribute(:video_url, 'new_video.com')
+      expect(Article.first.mom_growth_in_case_updates).to eq(100)
+    end
+
+    it 'returns the correct percentage increase for recent case growth rate' do
+      article = FactoryBot.create(:article, date: 31.days.ago)
+      article2 = FactoryBot.create(:article)
+      expect(Article.first.mom_new_cases_growth).to eq(0)
+    end
+
+    it 'returns the correct percentage increase for total case growth rate' do
+      article = FactoryBot.create(:article, created_at: 31.days.ago)
+      article2 = FactoryBot.create(:article)
+      expect(Article.first.mom_cases_growth).to eq(100)
+    end
   end
-end
 
-describe 'recent case growth rate' do
-  it 'returns the correct percentage increase' do
-    article = FactoryBot.create(:article, date: 31.days.ago)
-    article2 = FactoryBot.create(:article)
-    expect(Article.first.mom_new_cases_growth).to eq(0)
-  end
-end
-
-describe 'total case growth rate' do
-  it 'returns the correct percentage increase' do
-    article = FactoryBot.create(:article, created_at: 31.days.ago)
-    article2 = FactoryBot.create(:article)
-    expect(Article.first.mom_cases_growth).to eq(100)
-  end
-end
-
-describe '#default_avatar_url' do
-  it 'takes the avatar''s default URL and turns this into a column' do
-    article = FactoryBot.create(:article)
-    avatar_mock = double('Avatar', url: 'https://avatar.com')
-    allow(article).to receive(:default_avatar_url).and_return(avatar_mock.url)
-    expect(article.default_avatar_url).to_not be_nil
+  describe '#default_avatar_url' do
+    it 'takes the avatar''s default URL and turns this into a column' do
+      article = FactoryBot.create(:article)
+      avatar_mock = double('Avatar', url: 'https://avatar.com')
+      allow(article).to receive(:default_avatar_url).and_return(avatar_mock.url)
+      expect(article.default_avatar_url).to_not be_nil
+    end
   end
 end


### PR DESCRIPTION
This PR adds specs for 2 out of 3 of the current scopes for the `Article` model (the remaining scope will be redone as multiple scopes).  The PR also alters `article_spec` to follow the style of `agency_spec`.