### PR TITLE
Refactors article scope for count over time for clarity.

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -11,7 +11,7 @@ class AnalyticsController < ApplicationController
     @visits = Visit.this_month
     @users = User.where(created_at: @last_days.days.ago..Time.now)
     @views = Ahoy::Event.where(name: '$view')
-    @articles = Article.this_month
+    @articles = Article.created_this_month
   end
 
   private

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -57,8 +57,8 @@ class Article < ActiveRecord::Base
   end
   # Scopes
   scope :created_this_month, -> { where(created_at: 1.month.ago.beginning_of_day..Date.today.end_of_day) }
-  scope :most_recent, -> (duration) { where(date: duration.beginning_of_day..Date.today.end_of_day) }
-  scope :recently_updated, -> (duration) { where(updated_at: duration.beginning_of_day..Date.today.end_of_day) }
+  scope :most_recent, ->(duration) { where(date: duration.beginning_of_day..Date.today.end_of_day) }
+  scope :recently_updated, ->(duration) { where(updated_at: duration.beginning_of_day..Date.today.end_of_day) }
 
   def full_address
     "#{address} #{city} #{state.ansi_code} #{zipcode}".strip

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -56,8 +56,9 @@ class Article < ActiveRecord::Base
     art.avatar.changed?
   end
   # Scopes
-  scope :this_month, -> { where(created_at: 1.month.ago.beginning_of_day..Date.today.end_of_day) }
-  scope :property_count_over_time, ->(property, days) { where("#{property}": days.to_s.to_i.days.ago..Time.now).count }
+  scope :created_this_month, -> { where(created_at: 1.month.ago.beginning_of_day..Date.today.end_of_day) }
+  scope :most_recent, -> (duration) { where(date: duration.beginning_of_day..Date.today.end_of_day) }
+  scope :recently_updated, -> (duration) { where(updated_at: duration.beginning_of_day..Date.today.end_of_day) }
 
   def full_address
     "#{address} #{city} #{state.ansi_code} #{zipcode}".strip
@@ -96,26 +97,26 @@ class Article < ActiveRecord::Base
   end
 
   def mom_new_cases_growth
-    last_month_cases = Article.property_count_over_time('date', 30)
-    last_60_days_cases = Article.property_count_over_time('date', 60)
+    last_month_cases = Article.most_recent(30.days.ago).count
+    last_60_days_cases = Article.most_recent(60.days.ago).count
     prior_30_days_cases = last_60_days_cases - last_month_cases
 
     (((last_month_cases.to_f / prior_30_days_cases) - 1) * 100).round(2)
   end
 
   def mom_cases_growth
-    last_month_cases = Article.property_count_over_time('created_at', 30)
+    last_month_cases = Article.created_this_month.count
 
     (last_month_cases.to_f / (Article.count - last_month_cases) * 100).round(2)
   end
 
   def cases_updated_last_30_days
-    Article.property_count_over_time('updated_at', 30)
+    Article.recently_updated(30.days.ago).count
   end
 
   def mom_growth_in_case_updates
-    last_month_case_updates = Article.property_count_over_time('updated_at', 30)
-    last_60_days_case_updates = Article.property_count_over_time('updated_at', 60)
+    last_month_case_updates = Article.recently_updated(30.days.ago).count
+    last_60_days_case_updates = Article.recently_updated(60.days.ago).count
     prior_30_days_case_updates = last_60_days_case_updates - last_month_case_updates
 
     (((last_month_case_updates.to_f / prior_30_days_case_updates) - 1) * 100).round(2)

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -242,10 +242,56 @@ RSpec.describe Article, type: :model, versioning: true do
                                      state_id: dc.id,
                                      created_at: 1.year.ago)
 
-      recent_article = Article.this_month
+      recent_article = Article.created_this_month
       expect(recent_article.count).to eq 1
       expect(recent_article.to_a).not_to include(louisiana_article)
       expect(recent_article.to_a).not_to include(dc_article)
+    end
+
+    it 'returns the most recently occurring cases' do
+      dc = FactoryBot.create(:state_dc)
+      louisiana = FactoryBot.create(:state_louisiana)
+      texas = FactoryBot.create(:state_texas)
+
+      texas_article = FactoryBot.create(:article,
+                                        city: 'Houston',
+                                        state_id: texas.id,
+                                        date: Date.today)
+      louisiana_article = FactoryBot.create(:article,
+                                            city: 'Baton Rouge',
+                                            state_id: louisiana.id,
+                                            date: 2.weeks.ago)
+      dc_article = FactoryBot.create(:article,
+                                     city: 'Washington',
+                                     state_id: dc.id,
+                                     date: 1.year.ago)
+
+      recent_articles = Article.most_recent 1.month.ago
+      expect(recent_articles.count).to eq 2
+      expect(recent_articles.to_a).not_to include(dc_article)
+    end
+
+    it 'returns the most recently updated cases' do
+      dc = FactoryBot.create(:state_dc)
+      louisiana = FactoryBot.create(:state_louisiana)
+      texas = FactoryBot.create(:state_texas)
+
+      texas_article = FactoryBot.create(:article,
+                                        city: 'Houston',
+                                        state_id: texas.id,
+                                        updated_at: Date.today)
+      louisiana_article = FactoryBot.create(:article,
+                                            city: 'Baton Rouge',
+                                            state_id: louisiana.id,
+                                            updated_at: 2.weeks.ago)
+      dc_article = FactoryBot.create(:article,
+                                     city: 'Washington',
+                                     state_id: dc.id,
+                                     updated_at: 1.year.ago)
+
+      recent_articles = Article.recently_updated 1.month.ago
+      expect(recent_articles.count).to eq 2
+      expect(recent_articles.to_a).not_to include(dc_article)
     end
   end
 end


### PR DESCRIPTION
Previously, the `article` model had a scope for `property_count_over_time`, where you could specify the property (e.g., `date`, `created_at`, etc) and the time period and it would return the number of applicable articles.  Since we only called this for a couple of properties and durations, this PR refactors that scope by replacing it with multiple scopes for each property that take a duration as a parameter.  The new scopes return the Activerecord relation, and when the scope is called the calling function is responsible for using method chaining to obtain the count.  This also opens the interface and makes it easier to reuse the scope as needed.