### PR TITLE
Refactors state from agency scope

### DIFF
--- a/app/controllers/agencies_controller.rb
+++ b/app/controllers/agencies_controller.rb
@@ -14,6 +14,7 @@ class AgenciesController < ApplicationController
   def show
     @back_url = session[:previous_url]
     @articles = @agency.articles
+    @agency_state = @agency.retrieve_state
   end
 
   # GET /agencies/new

--- a/app/models/agency.rb
+++ b/app/models/agency.rb
@@ -46,4 +46,8 @@ class Agency < ActiveRecord::Base
       %i[name street_address city]
     ]
   end
+
+  def retrieve_state
+    State.where(id: state_id).pluck(:name).join
+  end
 end

--- a/app/models/state.rb
+++ b/app/models/state.rb
@@ -4,6 +4,4 @@ class State < ActiveRecord::Base
   has_many :articles
   has_many :agencies
   searchkick
-
-  scope :from_agency, ->(agency) { where(id: agency.state_id) }
 end

--- a/app/views/agencies/show.html.erb
+++ b/app/views/agencies/show.html.erb
@@ -6,7 +6,7 @@
 <span  class="page-header articleTitle">
   <h1 class="page-header articleTitle"><%= @agency.name %></h1>
   <h4><%= @agency.street_address %></h4>
-  <h4><%= @agency.city %>, <%= State.from_agency(@agency).first.name %> <%= @agency.zipcode %></h4>
+  <h4><%= @agency.city %>, <%= @agency_state %> <%= @agency.zipcode %></h4>
 </span>
 
 <% if @agency.jurisdiction.present? %>

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -60,4 +60,10 @@ RSpec.describe Agency, type: :model do
     end
   end
 
+  it 'retrieves the state of the agency' do
+    agency = FactoryBot.create(:agency, state_id: @texas.id)
+    agency_state = agency.retrieve_state
+    expect(agency_state).to eq @texas.name
+  end
+
 end


### PR DESCRIPTION
The branch name here is a bit of a misnomer, because in the process of adding this spec I realized that this particular scope shouldn't exist.  The scope was being used to determine the name of the state of an agency within the `agency#show` view.  Instead, this PR uses a class method on the `Agency` model to retrieve the corresponding state name, and passes that value as an instance variable from the controller to the view template.