### PR TITLE
Adds specs for statistics methods and refactoring for related models

### DIFF
--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -102,7 +102,7 @@ class Article < ActiveRecord::Base
     return 0 if last_month_cases.zero?
     last_60_days_cases = Article.most_recent(60.days.ago).count
     prior_30_days_cases = last_60_days_cases - last_month_cases
-    return (last_month_cases*100) if prior_30_days_cases.zero?
+    return (last_month_cases * 100) if prior_30_days_cases.zero?
 
     (((last_month_cases.to_f / prior_30_days_cases) - 1) * 100).round(2)
   end
@@ -111,7 +111,7 @@ class Article < ActiveRecord::Base
     last_month_cases = Article.created_this_month.count
     return 0 if last_month_cases.zero?
     previous_cases = Article.count - last_month_cases
-    return (last_month_cases*100) if previous_cases.zero?
+    return (last_month_cases * 100) if previous_cases.zero?
 
     (last_month_cases.to_f / (Article.count - last_month_cases) * 100).round(2)
   end
@@ -125,7 +125,7 @@ class Article < ActiveRecord::Base
     return 0 if last_month_case_updates.zero?
     last_60_days_case_updates = Article.recently_updated(60.days.ago).count
     prior_30_days_case_updates = last_60_days_case_updates - last_month_case_updates
-    return (last_month_case_updates*100) if prior_30_days_case_updates.zero?
+    return (last_month_case_updates * 100) if prior_30_days_case_updates.zero?
 
     (((last_month_case_updates.to_f / prior_30_days_case_updates) - 1) * 100).round(2)
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -55,8 +55,9 @@ class Article < ActiveRecord::Base
   before_save :set_default_avatar_url if proc do |art|
     art.avatar.changed?
   end
+
   # Scopes
-  scope :created_this_month, -> { where(created_at: 1.month.ago.beginning_of_day..Date.today.end_of_day) }
+  scope :created_this_month, -> { where(created_at: 30.days.ago.beginning_of_day..Date.today.end_of_day) }
   scope :most_recent, ->(duration) { where(date: duration.beginning_of_day..Date.today.end_of_day) }
   scope :recently_updated, ->(duration) { where(updated_at: duration.beginning_of_day..Date.today.end_of_day) }
 
@@ -98,14 +99,19 @@ class Article < ActiveRecord::Base
 
   def mom_new_cases_growth
     last_month_cases = Article.most_recent(30.days.ago).count
+    return 0 if last_month_cases.zero?
     last_60_days_cases = Article.most_recent(60.days.ago).count
     prior_30_days_cases = last_60_days_cases - last_month_cases
+    return (last_month_cases*100) if prior_30_days_cases.zero?
 
     (((last_month_cases.to_f / prior_30_days_cases) - 1) * 100).round(2)
   end
 
   def mom_cases_growth
     last_month_cases = Article.created_this_month.count
+    return 0 if last_month_cases.zero?
+    previous_cases = Article.count - last_month_cases
+    return (last_month_cases*100) if previous_cases.zero?
 
     (last_month_cases.to_f / (Article.count - last_month_cases) * 100).round(2)
   end
@@ -116,8 +122,10 @@ class Article < ActiveRecord::Base
 
   def mom_growth_in_case_updates
     last_month_case_updates = Article.recently_updated(30.days.ago).count
+    return 0 if last_month_case_updates.zero?
     last_60_days_case_updates = Article.recently_updated(60.days.ago).count
     prior_30_days_case_updates = last_60_days_case_updates - last_month_case_updates
+    return (last_month_case_updates*100) if prior_30_days_case_updates.zero?
 
     (((last_month_case_updates.to_f / prior_30_days_case_updates) - 1) * 100).round(2)
   end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -8,19 +8,28 @@ class Follow < ActiveRecord::Base
   belongs_to :followable, polymorphic: true, counter_cache: true
   belongs_to :follower,   polymorphic: true
 
+  # Scopes
+  scope :this_month, -> { where(created_at: 30.days.ago.beginning_of_day..Date.today.end_of_day) }
+
   def block!
     update_attribute(:blocked, true)
   end
 
   def mom_follows_growth
-    last_month_follows = Follow.where(created_at: 30.days.ago..Time.now).count
+    last_month_follows = Follow.this_month.count
+    return 0 if last_month_follows.zero?
+    previous_follows = Follow.count - last_month_follows
+    return (last_month_follows*100) if previous_follows.zero?
 
-    (last_month_follows.to_f / (Follow.count - last_month_follows) * 100).round(2)
+    (last_month_follows.to_f / previous_follows * 100).round(2)
   end
 
-  def mom_uniq_followers_growth
-    last_month_followers = Follow.where(created_at: 30.days.ago..Time.now).distinct.count('follower_id')
+  def mom_unique_followers_growth
+    last_month_followers = Follow.this_month.distinct.count('follower_id')
+    return 0 if last_month_followers.zero?
+    previous_distinct_followers = Follow.distinct.count('follower_id') - last_month_followers
+    return 0 if previous_distinct_followers.zero?
 
-    (last_month_followers.to_f / (Follow.distinct.count('follower_id') - last_month_followers) * 100).round(2)
+    (last_month_followers.to_f / previous_distinct_followers * 100).round(2)
   end
 end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -19,7 +19,7 @@ class Follow < ActiveRecord::Base
     last_month_follows = Follow.this_month.count
     return 0 if last_month_follows.zero?
     previous_follows = Follow.count - last_month_follows
-    return (last_month_follows*100) if previous_follows.zero?
+    return (last_month_follows * 100) if previous_follows.zero?
 
     (last_month_follows.to_f / previous_follows * 100).round(2)
   end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -12,7 +12,7 @@ class Visit < ActiveRecord::Base
     return 0 if last_month_visits.zero?
     last_60_days_visits = Visit.most_recent(60.days.ago).count
     prior_30_days_visits = last_60_days_visits - last_month_visits
-    return (last_month_visits*100) if prior_30_days_visits.zero?
+    return (last_month_visits * 100) if prior_30_days_visits.zero?
 
     (((last_month_visits.to_f / prior_30_days_visits) - 1) * 100).round(2)
   end

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -4,13 +4,15 @@ class Visit < ActiveRecord::Base
   has_many :ahoy_events, class_name: 'Ahoy::Event'
   belongs_to :user
 
-  scope :this_month, -> { where(started_at: 30.days.ago..Date.today.end_of_day) }
-  scope :property_count_over_time, ->(property, days) { where("#{property}": days.to_s.to_i.days.ago..Time.now).count }
+  scope :this_month, -> { where(started_at: 30.days.ago.beginning_of_day..Date.today.end_of_day) }
+  scope :most_recent, ->(duration) { where(started_at: duration.beginning_of_day..Date.today.end_of_day) }
 
   def mom_visits_growth
-    last_month_visits = Visit.property_count_over_time('started_at', 30)
-    last_60_days_visits = Visit.property_count_over_time('started_at', 60)
+    last_month_visits = Visit.this_month.count
+    return 0 if last_month_visits.zero?
+    last_60_days_visits = Visit.most_recent(60.days.ago).count
     prior_30_days_visits = last_60_days_visits - last_month_visits
+    return (last_month_visits*100) if prior_30_days_visits.zero?
 
     (((last_month_visits.to_f / prior_30_days_visits) - 1) * 100).round(2)
   end

--- a/app/views/analytics/_top_metrics.html.erb
+++ b/app/views/analytics/_top_metrics.html.erb
@@ -67,6 +67,6 @@
         <%= Follow.distinct.count('follower_id') %>
       </div>
       <small>
-        <%= Follow.first.mom_uniq_followers_growth %>% mom*
+        <%= Follow.first.mom_unique_followers_growth %>% mom*
       </small>
     </div>

--- a/spec/factories/visit.rb
+++ b/spec/factories/visit.rb
@@ -1,16 +1,16 @@
 FactoryBot.define do
-  factory :visit do
-    id 'b3a55b78-182c-459f-aaf0-890d9da33fe6'
-    visitor_id '2ba5754c-ae63-4f14-a704-1370842659f2'
-    ip '68.173.187.194'
-    user_agent 'Mozilla/5.0 (X11; Ubuntu; Linux x86_64; rv:38.0) Gecko/20100101 Firefox/38.0'
-    referrer ''
-    landing_page 'https://blackopswiki.herokuapp.com/'
-    browser 'Firefox'
-    os 'Ubuntu'
-    device_type 'desktop'
-    screen_height '1024'
-    screen_width '600'
-    started_at DateTime.now
+  factory :visit do |f|
+    f.sequence (:id) { SecureRandom.uuid }
+    f.visitor_id SecureRandom.uuid
+    f.ip Faker::Internet.ip_v4_address
+    f.user_agent Faker::Internet.user_agent(:firefox)
+    f.referrer ''
+    f.landing_page 'https://blackopswiki.herokuapp.com/'
+    f.browser 'Firefox'
+    f.os 'Ubuntu'
+    f.device_type 'desktop'
+    f.screen_height '1024'
+    f.screen_width '600'
+    f.started_at DateTime.now
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -192,25 +192,67 @@ RSpec.describe Article, type: :model, versioning: true do
   end
 
   describe 'growth' do
-    it 'returns correct percentage increase for growth_in_case_updates' do
-      article = FactoryBot.create(:article, updated_at: 31.days.ago)
-      article2 = FactoryBot.create(:article)
-      article3 = FactoryBot.create(:article, updated_at: 10.days.ago)
-      article2.update_attribute(:video_url, 'new_video.com')
-      expect(Article.first.mom_growth_in_case_updates).to eq(100)
+    describe 'growth_in_case_updates' do
+      it 'returns the correct percentage increase' do
+        article = FactoryBot.create(:article, updated_at: 31.days.ago)
+        article2 = FactoryBot.create(:article)
+        article3 = FactoryBot.create(:article, updated_at: 10.days.ago)
+        article2.update_attribute(:video_url, 'new_video.com')
+        expect(Article.first.mom_growth_in_case_updates).to eq(100)
+      end
+
+      it 'returns 0 if no updates in last 30 days' do
+        article = FactoryBot.create(:article, updated_at: 31.days.ago)
+        expect(Article.first.mom_growth_in_case_updates).to eq(0)
+      end
+
+      # What happens if there were updates between 0-30 days ago but none 31-60 days ago?
+      it 'returns correct percentage if previous 30 days period saw no updates' do
+        article = FactoryBot.create(:article, updated_at: 10.days.ago)
+        expect(Article.first.mom_growth_in_case_updates).to eq(100)
+      end
     end
 
-    it 'returns the correct percentage increase for recent case growth rate' do
-      article = FactoryBot.create(:article, date: 31.days.ago)
-      article2 = FactoryBot.create(:article)
-      expect(Article.first.mom_new_cases_growth).to eq(0)
+    describe 'new case growth rate' do
+      it 'returns the correct percentage increase' do
+        article = FactoryBot.create(:article, date: 31.days.ago)
+        article2 = FactoryBot.create(:article)
+        expect(Article.first.mom_new_cases_growth).to eq(0)
+      end
+
+      it 'returns 0 if no new cases in last 30 days' do
+        article = FactoryBot.create(:article, date: 31.days.ago)
+        expect(Article.first.mom_new_cases_growth).to eq(0)
+      end
+
+      # What happens if there were new cases between 0-30 days ago but none 31-60 days ago?
+      it 'returns correct percentage if previous 30 days period saw no new cases' do
+        article_one = FactoryBot.create(:article, date: 10.days.ago)
+        article_two = FactoryBot.create(:article, date: 15.days.ago)
+        expect(Article.first.mom_new_cases_growth).to eq(200)
+      end
     end
 
-    it 'returns the correct percentage increase for total case growth rate' do
-      article = FactoryBot.create(:article, created_at: 31.days.ago)
-      article2 = FactoryBot.create(:article)
-      expect(Article.first.mom_cases_growth).to eq(100)
+    describe 'total case growth rate' do
+      it 'returns the correct percentage increase' do
+        article = FactoryBot.create(:article, created_at: 31.days.ago)
+        article2 = FactoryBot.create(:article)
+        expect(Article.first.mom_cases_growth).to eq(100)
+      end
+
+      it 'returns 0 if no created cases in last 30 days' do
+        article = FactoryBot.create(:article, created_at: 31.days.ago)
+        expect(Article.first.mom_cases_growth).to eq(0)
+      end
+
+      #What happens if all of the cases were created in the past 30 days?
+      it 'returns correct percentage if all cases created in the past 30 days' do
+        article_one = FactoryBot.create(:article, date: 10.days.ago)
+        article_two = FactoryBot.create(:article, date: 15.days.ago)
+        expect(Article.first.mom_cases_growth).to eq(200)
+      end
     end
+
   end
 
   describe '#default_avatar_url' do

--- a/spec/models/follow_spec.rb
+++ b/spec/models/follow_spec.rb
@@ -2,22 +2,51 @@
 
 require 'rails_helper'
 
-RSpec.describe Subject, type: :model do
-  it 'follow growth rate returns the correct percentage' do
-    follow = FactoryBot.create(:follow, created_at: 31.days.ago)
-    follow2 = FactoryBot.create(:follow)
-    expect(Follow.first.mom_follows_growth).to eq(100)
+RSpec.describe Follow, type: :model do
+  describe 'growth rate' do
+    it 'returns the correct percentage' do
+      follow = FactoryBot.create(:follow, created_at: 31.days.ago)
+      follow2 = FactoryBot.create(:follow)
+      expect(Follow.first.mom_follows_growth).to eq(100)
+    end
+
+    it 'returns 0 if no new follows' do
+      follow = FactoryBot.create(:follow, created_at: 31.days.ago)
+      expect(Follow.first.mom_follows_growth).to eq(0)
+    end
+
+    it 'returns the correct percentage if all follows are within the past 30 days' do
+      follow_one = FactoryBot.create(:follow, created_at: 10.days.ago)
+      follow_two = FactoryBot.create(:follow, created_at: 15.days.ago)
+      expect(Follow.first.mom_follows_growth).to eq(200)
+    end
   end
 
-  it 'distinct followers is calculated correctly' do
-    follow = FactoryBot.create(:follow)
-    follow2 = FactoryBot.create(:follow, follower_id: 2)
-    expect(Follow.distinct.count('follower_id')).to eq(2)
+  describe 'distinct follower growth rate' do
+    it 'returns the correct percentage' do
+      follow_one = FactoryBot.create(:follow, follower_id: 1, created_at: 31.days.ago)
+      follow_two = FactoryBot.create(:follow, follower_id: 2, created_at: 10.days.ago)
+      expect(Follow.first.mom_unique_followers_growth).to eq(100)
+    end
+
+    it 'returns 0 if no distinct followers' do
+      follow_one = FactoryBot.create(:follow, follower_id: 1, created_at: 31.days.ago)
+      follow_two = FactoryBot.create(:follow, follower_id: 1, created_at: 10.days.ago)
+      expect(Follow.first.mom_unique_followers_growth).to eq(0)
+    end
+
+    it 'returns 0 if no new distinct followers' do
+      follow = FactoryBot.create(:follow, created_at: 31.days.ago)
+      expect(Follow.first.mom_unique_followers_growth).to eq(0)
+    end
   end
 
-  it 'distinct follower growth rate returns the correct percentage' do
-    follow = FactoryBot.create(:follow, created_at: 31.days.ago)
-    follow2 = FactoryBot.create(:follow, follower_id: 2)
-    expect(Follow.first.mom_follows_growth).to eq(100)
+  describe 'scopes' do
+    it 'returns follows from the past month' do
+      follow_one = FactoryBot.create(:follow, created_at: 40.days.ago)
+      follow_two = FactoryBot.create(:follow, created_at: 15.days.ago)
+      expect(Follow.this_month.count).to eq(1)
+      expect(Follow.this_month.to_a).not_to include(follow_one)
+    end
   end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Visit, type: :model do
+  describe 'scopes' do
+
+    it 'returns visits in the past month' do
+      visit_one = FactoryBot.create(:visit, started_at: 31.days.ago)
+      visit_two = FactoryBot.create(:visit, started_at: 10.days.ago)
+      expect(Visit.this_month.count).to eq(1)
+      expect(Visit.this_month.to_a).not_to include(visit_one)
+    end
+
+    it 'returns the most recent visits' do
+      visit_one = FactoryBot.create(:visit, started_at: 50.days.ago)
+      visit_two = FactoryBot.create(:visit, started_at: 10.days.ago)
+      expect(Visit.most_recent(45.days.ago).count).to eq(1)
+      expect(Visit.most_recent(45.days.ago).to_a).not_to include(visit_one)
+    end
+  end
+
+  describe 'growth rate' do
+    it 'returns the correct percentage' do
+      visit_one = FactoryBot.create(:visit, started_at: 31.days.ago)
+      visit_two = FactoryBot.create(:visit)
+      expect(Visit.first.mom_visits_growth).to eq(0)
+    end
+
+    it 'returns 0 if no new visits' do
+      visit = FactoryBot.create(:visit, started_at: 31.days.ago)
+      expect(Visit.first.mom_visits_growth).to eq(0)
+    end
+
+    it 'returns the correct percentage if previous 30 days period saw no visits' do
+      visit = FactoryBot.create(:visit)
+      expect(Visit.first.mom_visits_growth).to eq(100)
+    end
+  end
+end


### PR DESCRIPTION
This branch originally started with a hotfix for the `Article.created_this_month` scope.  However, this PR also includes additional specs and refactoring related to calculating statistics for various models.  This PR also contains specs and refactoring related to scopes for the `Visit` model.  Finally, this PR changes the method `mom_uniq_follows_growth` to `mom_unique_follows_growth` - not really a reason to shorten the word "unique".