### PR TITLE
Hotfix to account for timezones

### DIFF
--- a/app/controllers/analytics_controller.rb
+++ b/app/controllers/analytics_controller.rb
@@ -7,7 +7,7 @@ class AnalyticsController < ApplicationController
     @last_days = 30
     @full_width_content = true
     @visits = Visit.this_month
-    @users = User.where(created_at: @last_days.days.ago..Time.now)
+    @users = User.where(created_at: @last_days.days.ago..Time.current)
     @views = Ahoy::Event.where(name: '$view')
     @articles = Article.created_this_month
   end

--- a/app/models/article.rb
+++ b/app/models/article.rb
@@ -57,9 +57,9 @@ class Article < ActiveRecord::Base
   end
 
   # Scopes
-  scope :created_this_month, -> { where(created_at: 30.days.ago.beginning_of_day..Date.today.end_of_day) }
-  scope :most_recent, ->(duration) { where(date: duration.beginning_of_day..Date.today.end_of_day) }
-  scope :recently_updated, ->(duration) { where(updated_at: duration.beginning_of_day..Date.today.end_of_day) }
+  scope :created_this_month, -> { where(created_at: 30.days.ago.beginning_of_day..Time.current) }
+  scope :most_recent, ->(duration) { where(date: duration.beginning_of_day..Time.current) }
+  scope :recently_updated, ->(duration) { where(updated_at: duration.beginning_of_day..Time.current) }
 
   def full_address
     "#{address} #{city} #{state.ansi_code} #{zipcode}".strip

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -9,7 +9,7 @@ class Follow < ActiveRecord::Base
   belongs_to :follower,   polymorphic: true
 
   # Scopes
-  scope :this_month, -> { where(created_at: 30.days.ago.beginning_of_day..Date.today.end_of_day) }
+  scope :this_month, -> { where(created_at: 30.days.ago.beginning_of_day..Time.current) }
 
   def block!
     update_attribute(:blocked, true)

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -4,8 +4,8 @@ class Visit < ActiveRecord::Base
   has_many :ahoy_events, class_name: 'Ahoy::Event'
   belongs_to :user
 
-  scope :this_month, -> { where(started_at: 30.days.ago.beginning_of_day..Date.today.end_of_day) }
-  scope :most_recent, ->(duration) { where(started_at: duration.beginning_of_day..Date.today.end_of_day) }
+  scope :this_month, -> { where(started_at: 30.days.ago.beginning_of_day..Time.current) }
+  scope :most_recent, ->(duration) { where(started_at: duration.beginning_of_day..Time.current) }
 
   def mom_visits_growth
     last_month_visits = Visit.this_month.count

--- a/app/views/analytics/index.html.erb
+++ b/app/views/analytics/index.html.erb
@@ -23,7 +23,7 @@
           Visits by browser - last 24 hours
         </div>
         <div class="chart-stage">
-          <div id=""><%= pie_chart @visits.where(started_at: 1.days.ago..Time.now).group(:browser).count %></div>
+          <div id=""><%= pie_chart @visits.where(started_at: 1.days.ago..Time.current).group(:browser).count %></div>
         </div>
         <div class="chart-notes">
           Notes go down here
@@ -54,7 +54,7 @@
           Referring Domains - last 24 hours
         </div>
         <div class="chart-stage">
-          <div id=""><%= pie_chart @visits.where(started_at: 1.day.ago..Time.now).group(:referring_domain).count %></div>
+          <div id=""><%= pie_chart @visits.where(started_at: 1.day.ago..Time.current).group(:referring_domain).count %></div>
         </div>
         <div class="chart-notes">
           These domains are where traffic has originated
@@ -134,7 +134,7 @@
             <th>Views</th>
            </tr>
 
-           <% Visit.where(started_at: 7.days.ago..Time.now).group(:landing_page).order('count_id DESC').limit(13).count(:id).each_with_index do |visit, i| %>
+           <% Visit.where(started_at: 7.days.ago..Time.current).group(:landing_page).order('count_id DESC').limit(13).count(:id).each_with_index do |visit, i| %>
             <tr>
               <% if Article.find_by_slug(visit[0].split('/').last).present? %>
                 <td><%= i %></td>

--- a/spec/factories/article.rb
+++ b/spec/factories/article.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     f.sequence(:title) { |n| "#{n}Title" }
     f.overview 'A new article'
     f.city 'Albany'
-    f.date Date.today
+    f.date Date.current
     f.state # { FactoryBot.create(:state) }
     f.subjects { [create(:subject)] }
     f.summary 'A summary of changes'

--- a/spec/factories/visit.rb
+++ b/spec/factories/visit.rb
@@ -11,6 +11,6 @@ FactoryBot.define do
     f.device_type 'desktop'
     f.screen_height '1024'
     f.screen_width '600'
-    f.started_at DateTime.now
+    f.started_at Time.current
   end
 end

--- a/spec/models/article_spec.rb
+++ b/spec/models/article_spec.rb
@@ -274,7 +274,7 @@ RSpec.describe Article, type: :model, versioning: true do
       texas_article = FactoryBot.create(:article,
                                        city: 'Houston',
                                        state_id: texas.id,
-                                       created_at: Date.today)
+                                       created_at: Time.current)
       louisiana_article = FactoryBot.create(:article,
                                             city: 'Baton Rouge',
                                             state_id: louisiana.id,
@@ -298,7 +298,7 @@ RSpec.describe Article, type: :model, versioning: true do
       texas_article = FactoryBot.create(:article,
                                         city: 'Houston',
                                         state_id: texas.id,
-                                        date: Date.today)
+                                        date: Time.current)
       louisiana_article = FactoryBot.create(:article,
                                             city: 'Baton Rouge',
                                             state_id: louisiana.id,
@@ -321,7 +321,7 @@ RSpec.describe Article, type: :model, versioning: true do
       texas_article = FactoryBot.create(:article,
                                         city: 'Houston',
                                         state_id: texas.id,
-                                        updated_at: Date.today)
+                                        updated_at: Time.current)
       louisiana_article = FactoryBot.create(:article,
                                             city: 'Baton Rouge',
                                             state_id: louisiana.id,


### PR DESCRIPTION
This PR changes all instances of `Date.today` and `Time.now` to `Time.current` to account for time zones.