### PR TITLE
for #93

### DIFF
--- a/app/models/ahoy/event.rb
+++ b/app/models/ahoy/event.rb
@@ -2,6 +2,7 @@
 
 module Ahoy
   class Event < ActiveRecord::Base
+    include Ahoy::Properties
     self.table_name = 'ahoy_events'
 
     belongs_to :visit


### PR DESCRIPTION
Adding `include Ahoy::Properties` to Ahoy::Event model.

This allows a query such as

`Ahoy::Event.where(name: "$click").where_properties(class: "info2".count`

to find the number of clicks on links with class "info2"

Clearly, using more descriptive class names will help us in presentng and analyzng this data.