### PR TITLE
Removes logic from partials.

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -47,7 +47,6 @@ class ApplicationController < ActionController::Base
     @state_objects ||= State.all
   end
 
-
   protected
 
   def configure_permitted_parameters

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
 
   before_action :configure_permitted_parameters, if: :devise_controller?
+  before_action :state_objects
 
   helper_method :mailbox, :conversation
 
@@ -41,6 +42,11 @@ class ApplicationController < ActionController::Base
     Rollbar.warning warning_message
     redirect_to '/'
   end
+
+  def state_objects
+    @state_objects ||= State.all
+  end
+
 
   protected
 

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -4,12 +4,16 @@ class ConversationsController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    @other_users = User.all.reject{ |u| u == current_user }.collect{|p| [ p.name, p.id ] }
+    @other_users = User.all.reject { |u| u == current_user }.collect { |p| [p.name, p.id] }
   end
 
   def create
     recipients = User.where(id: conversation_params[:recipients])
-    conversation = current_user.send_message(recipients, conversation_params[:body], conversation_params[:subject]).conversation
+    conversation = current_user
+                   .send_message(recipients,
+                                 conversation_params[:body],
+                                 conversation_params[:subject])
+                   .conversation
     flash[:success] = 'Your message was successfully sent!'
     redirect_to conversation_path(conversation)
   end

--- a/app/controllers/conversations_controller.rb
+++ b/app/controllers/conversations_controller.rb
@@ -4,7 +4,7 @@ class ConversationsController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    @other_users = User.all.reject { |u| u == current_user }
+    @other_users = User.all.reject{ |u| u == current_user }.collect{|p| [ p.name, p.id ] }
   end
 
   def create

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -30,10 +30,16 @@ module ApplicationHelper
   end
 
   def active_page_link(page, remote)
-    content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    content_tag :a, page, remote: remote, rel: link_text(page)
   end
 
   def page_link(page, url, remote)
-    link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+    link_to page, url, remote: remote, rel: link_text(page)
+  end
+
+  def link_text(page)
+    return 'next' if page.next?
+    return 'prev' if page.prev?
+    nil
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -28,4 +28,12 @@ module ApplicationHelper
     end
     @hash
   end
+
+  def active_page_link(page, remote)
+    content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+  end
+
+  def page_link(page, url, remote)
+    link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil))
+  end
 end

--- a/app/views/conversations/_form.html.erb
+++ b/app/views/conversations/_form.html.erb
@@ -1,7 +1,7 @@
 <%= form_for :conversation, url: :conversations, html: { class: "" } do |f| %>
     <div class="form-group">
       <%= f.label :recipients %>
-      <%= f.select(:recipients, @other_users.collect {|p| [ p.name, p.id ] }, {}, { multiple: true , class: "form-control select2", multiple:"multiple", placeholder: "Select other EBWiki users to message" })%>
+      <%= f.select(:recipients, @other_users, {}, { multiple: true , class: "form-control select2", multiple:"multiple", placeholder: "Select other EBWiki users to message" })%>
     </div>
     <div class="form-group">
       <%= f.label :subject %>

--- a/app/views/kaminari/_page.html.erb
+++ b/app/views/kaminari/_page.html.erb
@@ -1,9 +1,9 @@
 <% if page.current? %>
   <li class='active'>
-    <%= content_tag :a, page, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= active_page_link(page, remote) %>
   </li>
 <% else %>
   <li>
-    <%= link_to page, url, remote: remote, rel: (page.next? ? 'next' : (page.prev? ? 'prev' : nil)) %>
+    <%= page_link(page, url, remote) %>
   </li>
 <% end %>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -23,7 +23,7 @@
 		<%= form_tag articles_path, method: :get do %>
         <div class="navbar-form navbar-left">
           <%= select_tag(:state_id, 
-            options_from_collection_for_select(State.all, :id, :name), 
+            options_from_collection_for_select(@state_objects, :id, :name), 
             include_blank: "Filter By State",
             class: 'form-control select2') %>
         </div>

--- a/spec/views/articles/index.html.erb_spec.rb
+++ b/spec/views/articles/index.html.erb_spec.rb
@@ -11,6 +11,7 @@ RSpec.describe 'articles/index.html.erb', type: :view do
     assign(:articles, Kaminari.paginate_array([article1, article2]).page(1))
 
     assign(:recently_updated_articles, Article.sorted_by_update(2) )
+    assign(:state_objects, State.all)
     render
 
     expect(rendered).to match /John Doe/m

--- a/spec/views/articles/show.html.erb_spec.rb
+++ b/spec/views/articles/show.html.erb_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe 'articles/show.html.erb', type: :view do
       assign(:comments, article.comments)
       assign(:comment, Comment.new)
       assign(:subjects, article.subjects)
+      assign(:state_objects, State.all)
       render
       expect(rendered).not_to match /only a stub/m
     end
@@ -33,6 +34,7 @@ RSpec.describe 'articles/show.html.erb', type: :view do
       assign(:comments, article.comments)
       assign(:comment, Comment.new)
       assign(:subjects, article.subjects)
+      assign(:state_objects, State.all)
       render
       expect(response.body).to match /Legal Action/m
     end
@@ -45,6 +47,7 @@ RSpec.describe 'articles/show.html.erb', type: :view do
       assign(:comments, article.comments)
       assign(:comment, Comment.new)
       assign(:subjects, article.subjects)
+      assign(:state_objects, State.all)
       render
       expect(response.body).to match /Summary/m
     end
@@ -57,6 +60,7 @@ RSpec.describe 'articles/show.html.erb', type: :view do
       assign(:comments, article.comments)
       assign(:comment, Comment.new)
       assign(:subjects, article.subjects)
+      assign(:state_objects, State.all)
       render
       expect(response.body).to match /Community and Family/m
     end


### PR DESCRIPTION
This PR refactors various partials by removing logic and performing queries and Ruby methods in the corresponding controllers and helpers.

There is one gripe I have about this - I updated the header partial to use an instance variable for a list of states, rather than performing the query in the partial.  However, all I could do was set the instance variable via a `before_action` callback in the controller and just call it in the partial.  For some reason, I can't pass the values along in the partial as a local variable - it complains about an undefined local method or variable.  However, since we will be moving towards defining the states in a YAML file rather than doing a database query each time, this is a good compromise in the meantime.

This PR addresses issues #923, #924, and #925.