### PR TITLE
Fixed cases_followers_path reference to fix #1411

### DIFF
--- a/config/sitemap.rb
+++ b/config/sitemap.rb
@@ -27,7 +27,7 @@ SitemapGenerator::Sitemap.create do
   # Add all cases:
   Case.find_each do |this_case|
     add case_path(this_case), lastmod: this_case.updated_at
-    add case_followers_path(this_case), lastmod: this_case.updated_at
+    add cases_followers_path(this_case), lastmod: this_case.updated_at
   end
 end
 


### PR DESCRIPTION
- config/sitemap.rb - Changes case_folowers_path to
  cases_followers_path to fix error reported in sitemap.

Updates #1411

In your PR did you:

  - [ X ] Include a description of the changes?
  - [ X ] Mention the issue the PR addresses?
  - [ N/A ] Include screenshots of any changes to the UI?
  - [ X ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
There isn't a spec for this because `config/sitemap.rb` is a generated file that has been modified.  The fix for this is one character.