### PR TITLE
Uses sanitize helper to clean up logic in email templates.

### DIFF
--- a/app/views/mailboxer/message_mailer/new_message_email.text.erb
+++ b/app/views/mailboxer/message_mailer/new_message_email.text.erb
@@ -4,7 +4,7 @@ You have a new message: <%= @subject %>
 You have received a new message in your EBWiki inbox:
 
 -----------------------------------------------
-<%= @message.body.html_safe? ? @message.body : strip_tags(@message.body) %>
+<%= sanitize @message.body %>
 -----------------------------------------------
 
 Visit <%= root_url %> and go to your inbox for more info.

--- a/app/views/mailboxer/message_mailer/reply_message_email.text.erb
+++ b/app/views/mailboxer/message_mailer/reply_message_email.text.erb
@@ -4,7 +4,7 @@ You have a new reply: <%= @subject %>
 You have received a new reply at EBWiki.org:
 
 -----------------------------------------------
-<%= @message.body.html_safe? ? @message.body : strip_tags(@message.body) %>
+<%= sanitize @message.body %>
 -----------------------------------------------
 
 Visit <%= root_url %> and go to your inbox for more info.

--- a/app/views/mailboxer/notification_mailer/new_notification_email.html.erb
+++ b/app/views/mailboxer/notification_mailer/new_notification_email.html.erb
@@ -4,7 +4,7 @@
     <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
   </head>
   <body>
-    <h1>You have a new notification: <%= @notification.subject.html_safe? ? @notification.subject : strip_tags(@notification.subject) %></h1>
+    <h1>You have a new notification: <%= sanitize @notification.subject %></h1>
     <p>
       You have received a new notification:
     </p>

--- a/app/views/mailboxer/notification_mailer/new_notification_email.text.erb
+++ b/app/views/mailboxer/notification_mailer/new_notification_email.text.erb
@@ -4,7 +4,7 @@ You have a new notification: <%= @notification.subject.html_safe? ? @notificatio
 You have received a new notification:
 
 -----------------------------------------------
-<%= @notification.body.html_safe? ? @notification.body : strip_tags(@notification.body) %>
+<%= sanitize @notification.body %>
 -----------------------------------------------
 
 Visit <%= root_url %> and go to your notifications for more info.


### PR DESCRIPTION
This PR uses the `sanitize` helper to remove logic in email templates that removed any suspicious tags and formatting.  This PR addresses issues #926 and #1280.  No new specs are necessary at this time.

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [X] Add and/or update specs for your code?
