### PR TITLE
Put in fix for case editing issue

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -70,6 +70,8 @@ class CasesController < ApplicationController
       UserNotifier.send_followers_email(@this_case.followers, @this_case).deliver_now
       redirect_to @this_case
     else
+      @categories = Category.all
+      @states = State.all
       render 'edit'
     end
   end

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -9,10 +9,10 @@ RSpec.describe CasesController, type: :controller do
       :make_undo_link
     ).and_return('/cases/1')
   end
-  let(:cases) { FactoryBot.create_list(:case, 20) }
 
   describe '#index' do
     describe 'on success' do
+      let(:cases) { FactoryBot.create_list(:case, 20) }
       before(:each) { get :index }
       it 'assigns the first 12 cases to @cases' do
         expect(assigns(:cases)).to match_array cases[0..11]
@@ -27,13 +27,11 @@ RSpec.describe CasesController, type: :controller do
           raise ActionController::InvalidAuthenticityToken
         end
       end
-      describe 'index' do
-        it 'does not raise an error' do
-          expect { get :index }.not_to raise_error
-        end
-        it 'redirects to the home page' do
-          expect(get(:index)).to redirect_to('/')
-        end
+      it 'does not raise an error' do
+        expect { get :index }.not_to raise_error
+      end
+      it 'redirects to the home page' do
+        expect(get(:index)).to redirect_to('/')
       end
     end
   end
@@ -139,9 +137,19 @@ RSpec.describe CasesController, type: :controller do
 
     context 'when invalid' do
       let(:new_values) { attributes_for(:invalid_case) }
-      it 'redirects to the edit page' do
+      before(:each) do 
         patch :update, id: this_case.id, case: new_values
+      end
+      it 'redirects to the edit page' do
         expect(response).to render_template(:edit)
+      end
+      
+       it 'has a non-empty set of categories' do
+        expect(assigns['categories']).to_not be_nil
+      end
+      
+      it 'has a non-empty set of states' do
+        expect(assigns['states']).to_not be_nil
       end
     end
   end


### PR DESCRIPTION
Overall, there was an error occurring rendering the 'edit' template after a failed update. These changes were placed to stop that error from occurring.


- app/controllers/cases_controller.rb - Added Category.all & State.all
  to the edit form so that the page renders successfully

- spec/controllers/cases_controller_spec.rb - Added specs to confirm that
  those required values are in the rendered template

Updates #1556, #1557

In your PR did you:

  - [X] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
