### PR TITLE
Fixes incorrect create date for comments on analytics page

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -19,7 +19,7 @@ module AnalyticsHelper
   end
 
   def comment_created_at(comment)
-    comment.created_at.strftime('Y')
+    comment.created_at.strftime('%B %d, %Y')
   end
 
   def link_to_comment(comment, length)


### PR DESCRIPTION
This PR updates the analytics helper to list the creation date of a comment in the "Most Recent Comments" section.  Fixes #1578 

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
