### PR TITLE
Resolve deprecation warning

### DIFF
--- a/spec/controllers/analytics_controller_spec.rb
+++ b/spec/controllers/analytics_controller_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe AnalyticsController, type: :controller do
   describe 'GET #index without login' do
     it 'redirects to the sign in path' do
       get :index
-      subject.should redirect_to new_user_session_path
+      expect(response).to redirect_to new_user_session_path
     end
   end
 

--- a/spec/controllers/comments_controller_spec.rb
+++ b/spec/controllers/comments_controller_spec.rb
@@ -10,18 +10,14 @@ RSpec.describe CommentsController, type: :controller do
       expect(response).to have_http_status(:success)
     end
   end
-end
-RSpec.describe CommentsController, type: :controller do
-  let(:this_case) { FactoryBot.create(:case) }
+
   describe 'GET #new' do
     it 'returns http success' do
       get :new, case_id: this_case.id
       expect(response).to have_http_status(:success)
     end
   end
-end
-RSpec.describe CommentsController, type: :controller do
-  let(:this_case) { FactoryBot.create(:case) }
+
   describe 'Case comments' do
     let(:this_case) { FactoryBot.create(:case) }
     let(:comment) { this_case.comments.create(content: 'a pithy comment') }
@@ -29,11 +25,11 @@ RSpec.describe CommentsController, type: :controller do
 
     subject { comment }
 
-    it { should be_valid }
+    it { is_expected.to be_valid }
 
-    it { should respond_to(:content) }
-    it { should respond_to(:commentable_type) }
-    it { should respond_to(:commentable_id) }
+    it { is_expected.to respond_to(:content) }
+    it { is_expected.to respond_to(:commentable_type) }
+    it { is_expected.to respond_to(:commentable_id) }
 
     it 'creates a new comment with valid attributes' do
       comment_attr = attributes_for(:comment)

--- a/spec/controllers/conversations_controller_spec.rb
+++ b/spec/controllers/conversations_controller_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe ConversationsController, type: :controller do
     login_user
     it 'should be successful' do
       get :new
-      response.should be_success
+      expect(response).to be_success
     end
 
     it 'should have a current_user' do


### PR DESCRIPTION
#### What this PR Does
Fixes the deprecation warning raised by rspec because of using `should` syntax. The issue is referenced [here](https://github.com/EBWiki/EBWiki/issues/1494).

#### Points to note
While addressing this issue, I refactored `comments_controller_spec` to  DRY it up. Also, looking at the specs in the `Case Comments` block, it's my opinion that they are more model related than controller related. Are they be better suited for the model spec, i.e `comments_spec.rb`? If so, we can move them.

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [x] Add and/or update specs for your code?
