### PR TITLE
Add spec to test validate future dates

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -31,8 +31,7 @@ class Case < ActiveRecord::Base
   searchkick _all: false, default_fields: ['*']
 
   # Model Validations
-  validates :date, presence: { message: 'Please add a date.' }
-  validate :case_date_cannot_be_in_the_future
+  validate :case_date_validator
   validates :city, presence: { message: 'Please add a city.' }
   validates :state_id, presence: {
     message: 'Please specify the state where this incident occurred before saving.'
@@ -105,9 +104,9 @@ class Case < ActiveRecord::Base
     try(:nearbys, 50).try(:order, 'distance')
   end
 
-  def case_date_cannot_be_in_the_future
-    errors.add(:date, 'must be in the past') if
-    date.present? && date > Date.current
+  def case_date_validator
+    errors.add(:date, 'must be present') && return unless date.present?
+    errors.add(:date, 'must be in the past') if date > Date.current
   end
 
   def edit_summary

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Case, type: :model do
     it 'should not accept dates in the future' do
       this_case = build(:case, date: 10.days.from_now)
       expect(this_case).to be_invalid
+      expect(this_case.errors.to_a).to include('Date must be in the past')
     end
 
     it 'is invalid without a state_id' do

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -9,6 +9,11 @@ RSpec.describe Case, type: :model do
       expect(this_case).to be_invalid
     end
 
+    it 'should not accept dates in the future' do
+      this_case = build(:case, date: 10.days.from_now)
+      expect(this_case).to be_invalid
+    end
+
     it 'is invalid without a state_id' do
       this_case = build(:case, state_id: nil)
       expect(this_case).to be_invalid


### PR DESCRIPTION
#### What does this PR do?
Addresses issue [1576](https://github.com/EBWiki/EBWiki/issues/1576)

#### Notes
- A spec already exists to verify that a case cannot be created without a date. So I added one to verify that a case cannot be created with a date in the future
- I found it necessary to keep the logic that checks if date is present in `case_date_cannot_be_in_the_future`. The reason is that since we are checking that `date > Date.current`, then we should verify that date is not nil. I'm happy to hear other approaches/suggestions  on this though

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [x] Add and/or update specs for your code?
