### PR TITLE
Update gem devise and remove deprecation warning #1730

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -92,7 +92,7 @@ end
 
 gem 'bootstrap-sass'
 gem 'bootstrap3-datetimepicker-rails'
-gem 'devise', '4.0.0.rc1'
+gem 'devise', '4.0.3'
 gem 'rails_12factor', groups: %i[production staging]
 gem 'simple_form'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
     database_cleaner (1.3.0)
     debug_inspector (0.0.3)
     device_detector (1.0.1)
-    devise (4.0.0.rc1)
+    devise (4.0.3)
       bcrypt (~> 3.0)
       orm_adapter (~> 0.1)
       railties (>= 4.1.0, < 5.1)
@@ -702,7 +702,7 @@ DEPENDENCIES
   cocoon
   cucumber-rails
   database_cleaner (~> 1.3.0)
-  devise (= 4.0.0.rc1)
+  devise (= 4.0.3)
   dotenv-rails
   enumerated_type
   factory_bot_rails (~> 4.10)

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -17,7 +17,7 @@ Devise.setup do |config|
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
-   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -17,6 +17,7 @@ Devise.setup do |config|
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'
+   config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
 
   # ==> ORM configuration
   # Load and configure the ORM. Supports :active_record (default) and


### PR DESCRIPTION
In your PR did you:
Update gem devise to 4.0.3
- Solves #1730

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
