### PR TITLE
corrected a typo on the guidelines page - 'links' was written as 'inks'

### DIFF
--- a/app/views/static/guidelines.html.erb
+++ b/app/views/static/guidelines.html.erb
@@ -24,7 +24,7 @@
 </p>
 
 <p>Above all, it is important to understand that in contributing to EBWiki, users are expected to be civil and factual, respecting all points of view, and only add verifiable and factual information rather than personal views and opinions. Verification includes
-    cases, news stories and original documents. You can add as many inks as you like to support your edits and additions.</p>
+    cases, news stories and original documents. You can add as many links as you like to support your edits and additions.</p>
 
 
 <h3>Other helpful features</h3>


### PR DESCRIPTION
In your PR did you:

  - [X] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [X] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?

![screenshot from 2018-08-03 03-14-10](https://user-images.githubusercontent.com/35179392/43617648-4f447662-96cc-11e8-9905-2d7c6d709564.png)
![screenshot from 2018-08-03 03-20-35](https://user-images.githubusercontent.com/35179392/43617649-51066744-96cc-11e8-8c8b-4c1df17ee347.png)

(New issue, quick fix) Corrected a typo on the guidelines page - 'links' was written as 'inks' under "How to Edit Existing Cases", the last line.