### PR TITLE
use strong parameter in agency controller

### DIFF
--- a/app/controllers/agencies_controller.rb
+++ b/app/controllers/agencies_controller.rb
@@ -30,7 +30,7 @@ class AgenciesController < ApplicationController
   def create
     @back_url = session[:previous_url]
     @agency = Agency.new(agency_params.except(:jurisdiction))
-    @agency.jurisdiction_type = params[:jurisdiction]
+    @agency.jurisdiction_type = agency_params[:jurisdiction]
     respond_to do |format|
       if @agency.save
         format.html { redirect_to @back_url, notice: 'Agency was successfully created.' }
@@ -44,7 +44,7 @@ class AgenciesController < ApplicationController
   def update
     respond_to do |format|
       if @agency.update(agency_params.except(:jurisdiction))
-        @agency.jurisdiction_type = params[:jurisdiction]
+        @agency.jurisdiction_type = agency_params[:jurisdiction]
         format.html { redirect_to @agency, notice: 'Agency was successfully updated.' }
       else
         format.html { render :edit }


### PR DESCRIPTION
In your PR did you:
This pr replaces params[:jurisdiction] with agency_params[:jurisdiction] which is a strong parameter
Fixes #1922 

  - [ ] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
