### PR TITLE
Added a place to enter a Google Maps API Key for Geocoding

### DIFF
--- a/config/initializers/geocoder.rb
+++ b/config/initializers/geocoder.rb
@@ -7,7 +7,7 @@ Geocoder.configure(
   # IP address geocoding service (see below for supported options):
   ip_lookup: :maxmind,
   # to use an API key:
-  # api_key: '...',
+  api_key: ENV['GOOGLE_MAPS_API_KEY'],
   # geocoding service request timeout, in seconds (default 3):
   timeout: 5,
   # set default units to kilometers:


### PR DESCRIPTION
- config/initializers/geocoder.rb - the api_key property was enabled
  and linked to an environmental variable

Updates #1721

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
