### PR TITLE
Remove rails-observer gem  #1702

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,8 +26,6 @@ gem 'turbolinks', '~> 5.1'
 gem 'jquery-turbolinks', '~> 2.1'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 1.0', group: :doc
-# add back rails observer class removed from rails 4
-gem 'rails-observers'
 
 gem 'momentjs-rails'
 gem 'rack'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -519,8 +519,6 @@ GEM
       rails-deprecated_sanitizer (>= 1.0.1)
     rails-html-sanitizer (1.0.4)
       loofah (~> 2.2, >= 2.2.2)
-    rails-observers (0.1.5)
-      activemodel (>= 4.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
       rails_stdout_logging
@@ -762,7 +760,6 @@ DEPENDENCIES
   rack-cors (~> 1.0)
   rack-host-redirect (~> 1.3)
   rails (~> 4.2.10)
-  rails-observers
   rails_12factor
   rails_admin (~> 1.3.0)
   redis-namespace (~> 1.6)


### PR DESCRIPTION
In your PR did you:
Remove rails-observer gem 
Solves #1702
  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
