### PR TITLE
for #2098 Removed respond_to blocks in the organizations controller

### DIFF
--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -22,33 +22,29 @@ class OrganizationsController < ApplicationController
   # POST /organizations
   def create
     @organization = Organization.new(organization_params)
-
-    respond_to do |format|
-      if @organization.save
-        format.html { redirect_to @organization, notice: 'Organization was successfully created.' }
-      else
-        format.html { render :new }
-      end
+    if @organization.save
+      flash[:success] = 'Organization was successfully created.'
+      redirect_to @organization
+    else
+      render 'new'
     end
   end
 
   # PATCH/PUT /organizations/1
   def update
-    respond_to do |format|
-      if @organization.update(organization_params)
-        format.html { redirect_to @organization, notice: 'Organization was successfully updated.' }
-      else
-        format.html { render :edit }
-      end
+    if @organization.update(organization_params)
+      flash[:success] = 'Organization was successfully updated.'
+      redirect_to @organization
+    else
+      render 'edit'
     end
   end
 
   # DELETE /organizations/1
   def destroy
     @organization.destroy
-    respond_to do |format|
-      format.html { redirect_to organizations_url, notice: 'Organization was successfully destroyed.' }
-    end
+    flash[:success] = 'Organization was successfully destroyed.'
+    redirect_to organizations_url    
   end
 
   def after_sign_up_path_for(resource)

--- a/app/controllers/organizations_controller.rb
+++ b/app/controllers/organizations_controller.rb
@@ -44,7 +44,7 @@ class OrganizationsController < ApplicationController
   def destroy
     @organization.destroy
     flash[:success] = 'Organization was successfully destroyed.'
-    redirect_to organizations_url    
+    redirect_to organizations_url
   end
 
   def after_sign_up_path_for(resource)


### PR DESCRIPTION
In the organizations controller, I removed the ```respond_to blocks```  and just rendered/redirected the corresponding pages directly.

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
