### PR TITLE
for #2109 Removed unnecessary begin..rescue..end block

### DIFF
--- a/app/services/determine_visits_to_cases.rb
+++ b/app/services/determine_visits_to_cases.rb
@@ -5,18 +5,12 @@
 class DetermineVisitsToCases
   include Service
 
-  # The begin..rescue..end block is used to determine if the URL leads to an
-  # article without performing the same query twice (to check if the case
-  # exists and then retrieve the case object.  Once Ruby is upgraded to
-  # >= 2.5, the rescue can be performed directly within the each do..end block.
   def call(visit_info)
     cases = []
     visit_info.each do |(url, views)|
-      begin
-        this_case = Case.friendly.find(url.split('/').last)
-        cases << [this_case, views]
-      rescue ActiveRecord::RecordNotFound
-      end
+      this_case = Case.friendly.find(url.split('/').last)
+      cases << [this_case, views]
+    rescue ActiveRecord::RecordNotFound
     end
     cases
   end


### PR DESCRIPTION
Removed unnecessary begin..rescue..end block in ```app/services/determine_visits_to_cases.rb```

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
