### PR TITLE
[2093] Remove before test block in mailer spec

### DIFF
--- a/spec/mailers/user_notifier_spec.rb
+++ b/spec/mailers/user_notifier_spec.rb
@@ -3,11 +3,6 @@
 require 'rails_helper'
 PaperTrail.request.disable_model(Case)
 RSpec.describe UserNotifier, type: :mailer do
-  before(:each) do
-    ActionMailer::Base.perform_deliveries = true
-    ActionMailer::Base.deliveries = []
-  end
-
   after(:each) do
     ActionMailer::Base.deliveries.clear
   end


### PR DESCRIPTION
closes #2093 
In the user notifier spec, remove the before block in the send_follower_email spec.
In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
