### PR TITLE
[2093] Remove before test block in mailer spec

### DIFF
--- a/app/views/user_notifier/send_followers_email.html.erb
+++ b/app/views/user_notifier/send_followers_email.html.erb
@@ -1,6 +1,6 @@
 <h1> **ALERT** <%= @this_case.title %> update:</h1>
-<p>Case editor <%= User.find(@this_case.versions.last.paper_trail.whodunnit).name %>
+<p>Case editor <%= User.find(@this_case.versions.last.whodunnit).name %>
 has updated the <%= link_to @this_case.title, @this_case %> case on EBWiki today. To describe the update,
- <%= User.find(@this_case.versions.last.paper_trail.whodunnit).name %> says: "<%= @this_case.versions.last.comment%>".
+ <%= User.find(@this_case.versions.last.whodunnit).name %> says: "<%= @this_case.versions.last.comment%>".
 <p>
 <p> Please feel free to add any data you have on this or <%= link_to 'other cases', 'http://ebwiki.org' %>.</p>

--- a/spec/mailers/user_notifier_spec.rb
+++ b/spec/mailers/user_notifier_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe UserNotifier, type: :mailer do
     let(:mail) { UserNotifier.send_followers_email([follower], this_case) }
 
     before do
-      allow(this_case).to receive_message_chain('versions.last.paper_trail.whodunnit').and_return(User.last)
+      allow(this_case).to receive_message_chain('versions.last.whodunnit').and_return(User.last)
       allow(this_case).to receive_message_chain('versions.last.comment').and_return('Comment')
       allow(Rails.logger).to receive(:info)
       allow(User).to receive(:find).and_return(author)


### PR DESCRIPTION
closes #2093
In the user notifier spec, remove the before block in the send_follower_email spec.
In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
