### PR TITLE
[#2295]Display Agency name on edit agency page

### DIFF
--- a/app/views/agencies/edit.html.erb
+++ b/app/views/agencies/edit.html.erb
@@ -1,4 +1,4 @@
-<h1>Editing Agency</h1>
+<h1><%= "Editing Agency #{@agency.name}"%></h1>
 
 <%= render 'form' %>
 


### PR DESCRIPTION
closes #2295

Display Agency name on edit agency page

![edit-agency](https://user-images.githubusercontent.com/3390330/44957312-8e70b280-aeee-11e8-84c8-0068fcd1ed3f.png)

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [x] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
