### PR TITLE
Replace instances of make_undo_link comments with a flash message #1894

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -42,7 +42,8 @@ class CasesController < ApplicationController
     # This could be a very expensive query as the userbase gets larger.
     # TODO: Create a scope to send only to users who have chosen to receive email updates
     if @this_case.save
-      flash[:success] = 'Case was created!' # {make_undo_link}
+      flash[:success] = 'Case was created!'
+      flash[:undo] = @this_case.versions
       redirect_to @this_case
     else
       @agencies = SortCollectionOrdinally.call(Agency.all)
@@ -72,7 +73,8 @@ class CasesController < ApplicationController
     @this_case.remove_avatar! if @this_case.remove_avatar?
     @this_case.blurb = ActionController::Base.helpers.strip_tags(@this_case.blurb)
     if @this_case.update_attributes(case_params)
-      flash[:success] = 'Case was updated!' # {make_undo_link}
+      flash[:success] = 'Case was updated!'
+      flash[:undo] = @this_case.versions
       UserNotifier.send_followers_email(@this_case.followers, @this_case).deliver_now
       redirect_to @this_case
     else
@@ -86,7 +88,8 @@ class CasesController < ApplicationController
     begin
       @this_case = Case.friendly.find(params[:id])
       @this_case.destroy
-      flash[:success] = 'Case was removed!' # {make_undo_link}
+      flash[:success] = 'Case was removed!'
+      flash[:undo] = @this_case.versions
       UserNotifier.send_deletion_email(@this_case.followers, @this_case).deliver_now
     rescue ActiveRecord::RecordNotFound
       flash[:notice] = I18n.t('cases_controller.case_not_found_message')
@@ -110,7 +113,8 @@ class CasesController < ApplicationController
         # For undoing the create action
         @case_version.item.destroy
       end
-      flash[:success] = 'Undid that!' # {make_redo_link}
+      flash[:success] = 'Undid that!'
+      flash[:undo] = @this_case.versions
     rescue
       flash[:alert] = 'Failed undoing the action...'
     ensure


### PR DESCRIPTION
In your PR did you:
Replace instances of make_undo_link comments with a flash message 
- Solves #1894
  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
