### PR TITLE
Db validation for agency name presence #2450

### DIFF
--- a/db/migrate/20180926085044_validate_name_presence_on_agencies.rb
+++ b/db/migrate/20180926085044_validate_name_presence_on_agencies.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ValidateNamePresenceOnAgencies < ActiveRecord::Migration
+  def change
+    change_column :agencies, :name, :string, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -52,7 +52,7 @@ SET default_with_oids = false;
 
 CREATE TABLE public.agencies (
     id integer NOT NULL,
-    name character varying,
+    name character varying NOT NULL,
     street_address character varying,
     city character varying,
     state_id integer,
@@ -709,7 +709,7 @@ ALTER SEQUENCE public.states_id_seq OWNED BY public.states.id;
 
 CREATE TABLE public.subjects (
     id integer NOT NULL,
-    name character varying,
+    name character varying NOT NULL,
     age integer,
     gender_id integer,
     ethnicity_id integer,
@@ -1521,4 +1521,8 @@ INSERT INTO schema_migrations (version) VALUES ('20180816124609');
 INSERT INTO schema_migrations (version) VALUES ('20180904123943');
 
 INSERT INTO schema_migrations (version) VALUES ('20180911071251');
+
+INSERT INTO schema_migrations (version) VALUES ('20180926083147');
+
+INSERT INTO schema_migrations (version) VALUES ('20180926085044');
 


### PR DESCRIPTION
Add a database constraint that requires the name column for agencies to not be nil.
Solves #2450
In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
