### PR TITLE
Create a rake task to set the values of comments in versions table

### DIFF
--- a/lib/tasks/versions.rake
+++ b/lib/tasks/versions.rake
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+namespace :versions do
+  desc 'Set all nil comment attributes on versions to empty string'
+  task set_nil_comment: :environment do
+    sql_query = <<-END_SQL
+      UPDATE versions
+      SET comment = ''
+      WHERE comment IS NULL;
+    END_SQL
+
+    ActiveRecord::Base.connection.execute(sql_query)
+  end
+end

--- a/spec/lib/tasks/versions_spec.rb
+++ b/spec/lib/tasks/versions_spec.rb
@@ -1,0 +1,27 @@
+describe 'versions:set_nil_comment' do
+  include_context 'rake'
+
+  before do
+    sql_query = <<-END_SQL
+      INSERT INTO versions (item_type, item_id, event, comment)
+      VALUES ('users', 1, 'update', null);
+    END_SQL
+
+    ActiveRecord::Base.connection.execute(sql_query)
+  end
+
+  it 'should update the table' do
+    sql_query = <<-END_SQL
+      SELECT * 
+      FROM versions
+      WHERE comment IS NULL
+    END_SQL
+
+    results = ActiveRecord::Base.connection.execute(sql_query)
+    expect(results.ntuples).to_not eq 0
+
+    subject.invoke
+    results = ActiveRecord::Base.connection.execute(sql_query)
+    expect(results.ntuples).to eq 0
+  end
+end


### PR DESCRIPTION
Issue: https://github.com/EBWiki/EBWiki/issues/2406

Create a rake task to set the values of comments in versions table.
The task can be run using: `rake versions:set_nil_comment`

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [x] Include screenshots of any changes to the UI?
  - [x] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [x] Add and/or update specs for your code?
