### PR TITLE
Add database constraint for table cases on column city

### DIFF
--- a/db/migrate/20181003112438_add_not_nil_constraint_to_cases.rb
+++ b/db/migrate/20181003112438_add_not_nil_constraint_to_cases.rb
@@ -1,0 +1,5 @@
+class AddNotNilConstraintToCases < ActiveRecord::Migration
+  def change
+    change_column :cases, :city, :string, null: false
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -182,7 +182,7 @@ CREATE TABLE public.cases (
     category_id integer,
     date date,
     state_id integer,
-    city character varying,
+    city character varying NOT NULL,
     address character varying,
     zipcode character varying,
     longitude double precision,
@@ -1609,4 +1609,6 @@ INSERT INTO schema_migrations (version) VALUES ('20181003130555');
 INSERT INTO schema_migrations (version) VALUES ('20181005060647');
 
 INSERT INTO schema_migrations (version) VALUES ('20181008175901');
+
+INSERT INTO schema_migrations (version) VALUES ('20181003112438');
 


### PR DESCRIPTION
Issue: https://github.com/EBWiki/EBWiki/issues/2446

Added migration with not null constraint on table cases on column city

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [x] Include screenshots of any changes to the UI?
  - [x] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [x] Add and/or update specs for your code?
