### PR TITLE
Add database constraint between cases and subjects with the option on_delete: :cascade

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -12,7 +12,7 @@ class Case < ActiveRecord::Base
   accepts_nested_attributes_for :links, reject_if: :all_blank, allow_destroy: true
   has_many :comments, as: :commentable, dependent: :destroy
   has_many :follows, as: :followable, dependent: :destroy
-  has_many :subjects, dependent: :destroy
+  has_many :subjects
   accepts_nested_attributes_for :subjects, reject_if: :all_blank, allow_destroy: true
 
   has_many :case_agencies, dependent: :destroy

--- a/db/migrate/20181003130555_add_fk_subjects_cases_cascade.rb
+++ b/db/migrate/20181003130555_add_fk_subjects_cases_cascade.rb
@@ -1,0 +1,5 @@
+class AddFkSubjectsCasesCascade < ActiveRecord::Migration
+  def change
+    add_foreign_key :subjects, :cases, on_delete: :cascade
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1519,11 +1519,17 @@ INSERT INTO schema_migrations (version) VALUES ('20180904123943');
 
 INSERT INTO schema_migrations (version) VALUES ('20180911071251');
 
-INSERT INTO schema_migrations (version) VALUES ('20180926123043');
+INSERT INTO schema_migrations (version) VALUES ('20180926083147');
 
 INSERT INTO schema_migrations (version) VALUES ('20180926085044');
 
 INSERT INTO schema_migrations (version) VALUES ('20180926091204');
 
 INSERT INTO schema_migrations (version) VALUES ('20180926092536');
+
+INSERT INTO schema_migrations (version) VALUES ('20180926123043');
+
+INSERT INTO schema_migrations (version) VALUES ('20181003112438');
+
+INSERT INTO schema_migrations (version) VALUES ('20181003130555');
 


### PR DESCRIPTION
Add database constraint between cases and subjects with the option on_delete: :cascade

Issue: https://github.com/EBWiki/EBWiki/issues/2454

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [x] Include screenshots of any changes to the UI?
  - [x] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [x] Add and/or update specs for your code?
