### PR TITLE
Refactor the nearby_cases

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -96,7 +96,7 @@ class Case < ActiveRecord::Base
   end
 
   def nearby_cases
-    try(:nearbys, 50).try(:order, 'distance')
+    self&.nearbys(50)&.order('distance') || Case.none
   end
 
   def case_date_validator


### PR DESCRIPTION
It closes #2428 

- Replace the try calls for safe navigator
- Return a Case::ActiveRecord_Relation so we can iterate it as an array and also would be chainable with other active record instructions