### PR TITLE
#2492 update analytics route

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get 'analytics/index'
+  get '/analytics', to: 'analytics#index'
 
   get '/maps/index', to: 'maps#index'
 

--- a/spec/features/admin_visits_analytics_page_spec.rb
+++ b/spec/features/admin_visits_analytics_page_spec.rb
@@ -20,7 +20,7 @@ describe User do
       fill_in 'Email', with: admin.email
       fill_in 'Password', with: admin.password
       click_button 'Log in'
-      visit analytics_index_path
+      visit analytics_path
       expect(page).to have_content 'Recent Visits'
       WebMock.disable_net_connect!
     end


### PR DESCRIPTION
Update the analytics route to be the following:
 
```ruby
get '/analytics', to: 'analytics#index'
```

Also update corresponding spec.

Issue: #2492

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [x] Add and/or update specs for your code?
