### PR TITLE
Fixed - metatags keywords not rendering correctly on show page

### DIFF
--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -2,9 +2,9 @@
      title and meta tags in conjunction with the metamagic
      method in app/views/layouts/application.html.erb
      TODO: Create a view helper that works for all pages -->
-<% meta title: "EBWiki tracking the case of #{@this_case.title}",
+<% meta title: "#{@this_case.title} - #{@this_case.city} on EBWiki",
      description: "#{@this_case.blurb}",
-     keywords: %w("@this_case.subjects.first.name police violence people color")
+     keywords: %w("#{@this_case.subjects.first.name} police violence people color")
 %>
 <!-- Page Content -->
 <div class="container">


### PR DESCRIPTION
In your PR did you:
Fixed - Metatags keywords not rendering correctly on show page https://github.com/EBWiki/EBWiki/issues/2523

  - [ ] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
