### PR TITLE
Fix minor typo in .gitignore (issue #2580)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ bower.json
 .DS_Store
 
 # remove database.yml from files being pushed
-config/database.yml
+/config/database.yml


### PR DESCRIPTION
Slash added at the beginning of config/database.yml entry