### PR TITLE
add slugs column to ethnicities table

### DIFF
--- a/db/migrate/20181025220728_add_slugs_to_ethnicities.rb
+++ b/db/migrate/20181025220728_add_slugs_to_ethnicities.rb
@@ -1,0 +1,5 @@
+class AddSlugsToEthnicities < ActiveRecord::Migration
+  def change
+    add_column :ethnicities, :slug, :string
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -2,8 +2,8 @@
 -- PostgreSQL database dump
 --
 
--- Dumped from database version 9.5.14
--- Dumped by pg_dump version 9.5.14
+-- Dumped from database version 10.5
+-- Dumped by pg_dump version 10.5
 
 SET statement_timeout = 0;
 SET lock_timeout = 0;
@@ -1610,4 +1610,8 @@ INSERT INTO schema_migrations (version) VALUES ('20181003130555');
 INSERT INTO schema_migrations (version) VALUES ('20181005060647');
 
 INSERT INTO schema_migrations (version) VALUES ('20181008175901');
+
+INSERT INTO schema_migrations (version) VALUES ('20181013103240');
+
+INSERT INTO schema_migrations (version) VALUES ('20181025220728');
 

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -296,7 +296,8 @@ CREATE TABLE public.ethnicities (
     id integer NOT NULL,
     title character varying,
     created_at timestamp without time zone NOT NULL,
-    updated_at timestamp without time zone NOT NULL
+    updated_at timestamp without time zone NOT NULL,
+    slug character varying
 );
 
 


### PR DESCRIPTION
The database looks like it was requiring slugs for ethnicities when seeding the database, this pull request includes a migration that adds the slug column to the ethnicities database

Issue: https://github.com/EBWiki/EBWiki/issues/2626

  - [√] Include a description of the changes?
  - [√] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
