### PR TITLE
Fix#2647 

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
     stored_location_for(resource) || super
   end
 
-  def update_user
+  def update_user_email
     @user = User.find(params[:id])
     authorize @user
     if @user.update_attributes(user_param)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,9 +29,24 @@ class UsersController < ApplicationController
     stored_location_for(resource) || super
   end
 
+  def update_user
+    @user = User.find(params[:id])
+    authorize @user
+    if @user.update_attributes(user_param)
+      flash[:success] = 'Email updated Successfully!'
+      redirect_to @user
+    else
+      render 'edit'
+    end
+  end
+
   private
 
   def user_params
     params.require(:user).permit(:name, :email, :description, :subscribed)
+  end
+
+  def user_param
+    params.require(:user).permit(:email)
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -29,7 +29,7 @@ class UsersController < ApplicationController
     stored_location_for(resource) || super
   end
 
-  def update_user_email
+  def update_email
     @user = User.find(params[:id])
     authorize @user
     if @user.update_attributes(user_param)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
   root 'cases#index'
   resources :users do
     member do
-      patch "update_user_email" 
+      patch "update_email" 
     end
     resources :registrations
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
   root 'cases#index'
   resources :users do
     member do
-      patch "update_user" 
+      patch "update_user_email" 
     end
     resources :registrations
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -42,6 +42,9 @@ Rails.application.routes.draw do
 
   root 'cases#index'
   resources :users do
+    member do
+      patch "update_user" 
+    end
     resources :registrations
   end
 


### PR DESCRIPTION
Added endpoint for updating user email.
As mentioned in the #2647, this endpoint is similar to the current update action, expect that the only permitted attribute should be email.