### PR TITLE
Fixing new case not re-rendering upon failure

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -49,6 +49,7 @@ class CasesController < ApplicationController
       @agencies = SortCollectionOrdinally.call(collection: Agency.all)
       @categories = SortCollectionOrdinally.call(collection: Category.all)
       @states = SortCollectionOrdinally.call(collection: State.all)
+      @genders = SortCollectionOrdinally.call(collection: Gender.all, column_name: 'sex')
       render 'new'
     end
   end
@@ -114,7 +115,7 @@ class CasesController < ApplicationController
       end
       flash[:success] = 'Undid that!'
       flash[:undo] = @this_case.versions
-    rescue
+    rescue StandardError
       flash[:alert] = 'Failed undoing the action...'
     ensure
       redirect_to root_path

--- a/spec/controllers/cases_controller_spec.rb
+++ b/spec/controllers/cases_controller_spec.rb
@@ -103,7 +103,9 @@ RSpec.describe CasesController, type: :controller do
         allow_any_instance_of(Case).to receive(:full_address).and_return(' Albany NY ')
         post :create, 'case': case_attrs
         expect(assigns(:categories)).to match_array([])
+        expect(assigns(:agencies)).to match_array([])
         expect(assigns(:states)).to match_array([])
+        expect(assigns(:genders)).to match_array([])
         expect(response).to render_template(:new)
       end
     end
@@ -194,7 +196,7 @@ RSpec.describe CasesController, type: :controller do
     end
     context 'when requested case does not exists' do
       it 'returns a message that says that that case was not found' do
-        expect(delete :destroy, id: -1).to redirect_to root_path
+        expect(delete(:destroy, id: -1)).to redirect_to root_path
         expect(flash[:notice]).to eq(I18n.t('cases_controller.case_not_found_message'))
       end
     end

--- a/spec/features/editor_saves_case_spec.rb
+++ b/spec/features/editor_saves_case_spec.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+feature 'Editor edits an case' do
+  let(:this_case) { FactoryBot.create(:case) }
+  scenario 'Editor tries to save a case and fails' do
+    user = FactoryBot.create(:user)
+    login_as(user, scope: :user)
+    visit "/cases/new"
+    click_button "Create Case"
+    expect(page).to have_content('New Case')
+  end
+end


### PR DESCRIPTION
- app/controllers/cases_controller.rb - Added the @genders variable
  to the failure save on the create method

- spec/controllers/cases_controller_spec.rb - Spec that confirms that
  the genders variable has been assigned

- spec/features/editor_saves_case_spec.rb - Feature spec to show that
  the new case page will display properrly if a user tries to save
  and fails

Updates #2610

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [X] Add and/or update specs for your code?
