### PR TITLE
for #2490 fixing summary field to be clear when user edits case

### DIFF
--- a/app/views/cases/_form.html.erb
+++ b/app/views/cases/_form.html.erb
@@ -114,7 +114,7 @@
 <div class="cold-md-12">
   <fieldset class="fsStyle">
     <legend class="legendStyle">Summary of Changes to the Case <%= image_tag('help_icon.png', data: {:toggle => 'popover', :container => 'body', :trigger => 'hover',:placement => "bottom", :title => "Main Content Fields", :content => "Please summarize the edits you have made to this case.  These summaries populate the history tabs to make the history of the case more readable to users."})%></legend>
-    <%= f.input :summary, as: :text, value: nil %>
+    <%= f.input :summary, :input_html => { :value => nil }, value: nil  %>
   </fieldset>
 </div>
   <br>


### PR DESCRIPTION
Changed one line in the form to clear the summary field in the edit form.

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
