### PR TITLE
Removes CSS rule that produces scroll bar

### DIFF
--- a/app/assets/stylesheets/cases.scss
+++ b/app/assets/stylesheets/cases.scss
@@ -32,7 +32,6 @@ $color-dark-gray: #4D4D4D;
 
 #front-gallery {
     max-height:500px;
-    overflow-y:scroll;
     margin-bottom: 30px;
 }
 


### PR DESCRIPTION
The more hotfixes, the merrier apparently.  But this will remove the scroll bar from the front page gallery.

Will merge immediately after tests pass.
