### PR TITLE
Fix typo: firs -> first

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -237,7 +237,7 @@ if Case.count.zero?
                                     }
                            },
       city: 'Pensacola',
-      state_id: State.find_by(name: 'Florida').firs,
+      state_id: State.find_by(name: 'Florida').first,
       overview: 'a',
       blurb: 'Kari Holm',
       summary: 'Added a case' },


### PR DESCRIPTION
- This PR fixes a type in db/seeds.rb
- With the typo, there was an issue running `rake db:seed`
- No UI changes
- No gem changes
- No spec updates