### PR TITLE
Adds partials for case thumbnails

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -4,6 +4,7 @@
 class UsersController < ApplicationController
   def show
     @user = User.find(params[:id])
+    @cases = @user.all_following
   end
 
   def edit

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -2,6 +2,8 @@
 
 # EBWiki Users controller
 class UsersController < ApplicationController
+  around_action :skip_bullet, only: :show
+
   def show
     @user = User.find(params[:id])
     @cases = @user.all_following
@@ -54,4 +56,12 @@ class UsersController < ApplicationController
   def mailbox
     @mailbox ||= current_user.mailbox
  end
+
+ def skip_bullet
+    previous_value = Bullet.enable?
+    Bullet.enable = false
+    yield
+  ensure
+    Bullet.enable = true
+  end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -62,6 +62,6 @@ class UsersController < ApplicationController
     Bullet.enable = false
     yield
   ensure
-    Bullet.enable = true
+    Bullet.enable = previous_value
   end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -55,9 +55,9 @@ class UsersController < ApplicationController
 
   def mailbox
     @mailbox ||= current_user.mailbox
- end
+  end
 
- def skip_bullet
+  def skip_bullet
     previous_value = Bullet.enable?
     Bullet.enable = false
     yield

--- a/app/views/agencies/show.html.erb
+++ b/app/views/agencies/show.html.erb
@@ -35,33 +35,15 @@
 <%= link_to 'Back', session[:previous_url], :class => "btn-default" %>
 <%= link_to 'Edit', edit_agency_path(@agency), :class => "btn-warning" %>
 
-<!-- Related Projects Row -->
+<!-- Related Cases Row -->
 <div class="row">
   <div class="col-lg-12">
-    <h3 class="page-header">EBWiki is tracking <%= pluralize(@agency.cases.count, "case")%> involving the <%= @agency.name %>:</h3>
+    <h3 class="page-header">EBWiki is tracking <%= pluralize(@cases.size, "case")%> involving the <%= @agency.name %>:</h3>
   </div>
 </div>
 <div class="row">
   <div class="col-lg-12">
-    <% @agency.cases.each do |this_case| %>
-      <div class="col-lg-2 col-md-4 col-xs-12">
-        <div class="view view-first">
-          <% if this_case.avatar? %>
-            <%= link_to image_tag(this_case.avatar.large_avatar, :class => "img-responsive"), this_case %>
-          <% else %>
-            <div class="thumbnail text-center">
-              <%= link_to image_tag("default-user-icon.png", :class => "img-responsive"), this_case %>
-              <div class="caption">
-                <h4><%= this_case.title %></h4>
-              </div>
-            </div>
-          <% end %>
-          <div class="mask">
-            <h2><%= link_to this_case.title, this_case, :class => "info2" %></h2>
-          </div>
-        </div>
-      </div>
-    <% end %>
+    <%= render partial: 'cases/thumbnail', layout: 'cases/show_thumbnail', collection: @cases, as: :this_case %>
   </div>
 </div>
 

--- a/app/views/cases/_index_thumbnail.html.erb
+++ b/app/views/cases/_index_thumbnail.html.erb
@@ -1,0 +1,5 @@
+<!-- Layout for case thumbnails on cases/index -->
+
+<div class="col-lg-3 col-md-4 col-xs-2">
+  <%= yield %>
+</div>

--- a/app/views/cases/_show_thumbnail.html.erb
+++ b/app/views/cases/_show_thumbnail.html.erb
@@ -1,0 +1,5 @@
+<!-- Layout for case thumbnails on agencies/show and users/show -->
+
+<div class="col-lg-2 col-md-4 col-xs-12">
+  <%= yield %>
+</div>

--- a/app/views/cases/_thumbnail.html.erb
+++ b/app/views/cases/_thumbnail.html.erb
@@ -1,18 +1,16 @@
-<div class="col-lg-3 col-md-4 col-xs-2">
-  <div class="view view-first">
-    <div class="thumbnail text-center">
-      <% if this_case.avatar? %>
-        <%= link_to image_tag(this_case.avatar.large_avatar, :class => "img-responsive"), this_case %>
-      <% else %>
-        <%= link_to image_tag("default-user-icon.png", :class => "img-responsive"), this_case %>
-        <div class="caption">
-          <h4><%= this_case.subjects.first.name %></h4>
-        </div>
-      <% end %>
-    </div>
-    <div class="mask">
-      <h2><%= link_to this_case.title, this_case, :class => "info2" %></h2>
-      <h5><%= this_case.date.strftime("%B %d, %Y") %> - <%= this_case.city %>, <%= this_case.state.ansi_code %></h5>
-    </div>
+<div class="view view-first">
+  <div class="thumbnail text-center">
+    <% if this_case.avatar? %>
+      <%= link_to image_tag(this_case.avatar.large_avatar, :class => "img-responsive"), this_case %>
+    <% else %>
+      <%= link_to image_tag("default-user-icon.png", :class => "img-responsive"), this_case %>
+      <div class="caption">
+        <h4><%= this_case.subjects.first.name %></h4>
+      </div>
+    <% end %>
+  </div>
+  <div class="mask">
+    <h2><%= link_to this_case.title, this_case, :class => "info2" %></h2>
+    <h5><%= this_case.date.strftime("%B %d, %Y") %> - <%= this_case.city %>, <%= this_case.state.ansi_code %></h5>
   </div>
 </div>

--- a/app/views/cases/index.html.erb
+++ b/app/views/cases/index.html.erb
@@ -18,7 +18,7 @@
       <h4 class="page-subheader">
         <%= link_to "What next?", "https://www.surveymonkey.com/r/5RSWFNY", data: {:toggle => 'popover', :container => 'body', :trigger => 'hover',:placement => "bottom",:title => "What's next for EBWiki?",:content => "Click here to help us decide on a few features we are thinking of adding to EBWiki!"} %>-- <%= link_to 'More about us...',about_path %></h4>
       <div id='front-gallery'>
-        <%= render partial: 'thumbnail', collection: @cases, as: :this_case %>
+        <%= render partial: 'thumbnail', layout: "index_thumbnail", collection: @cases, as: :this_case %>
       </div>
       <%= paginate @cases %>
       <p><%= page_entries_info @cases %></p>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -31,32 +31,14 @@
           <h3 class="page-header">Cases <%= @user.name %> follows:</h3>
         <% else %>
           <h3 class="page-header">
-            <% if @user.all_following.count == 0 %>
+            <% if @cases.size.zero? %>
               Please take 30 seconds and <%= link_to 'pick a case', root_path %> that you want to track and click the follow button. We'll take it from there to keep you informed.
             <% else %>
               <h3 class="page-header">Cases we are tracking for you:</h3>
             <% end %>
           </h3>
         <% end %>
-        <% @user.all_following.each do |following_case| %>
-          <div class="col-lg-2 col-md-4 col-xs-12">
-              <div class="view view-first">
-                <% if following_case.avatar? %>
-                  <%= link_to image_tag(following_case.avatar.large_avatar, :class => "img-responsive"), following_case %>
-                <% else %>
-                  <div class="thumbnail text-center">
-                    <%= link_to image_tag("default-user-icon.png", :class => "img-responsive"), following_case %>
-                    <div class="caption">
-                      <h4><%= following_case.subjects.first.name %></h4>
-                    </div>
-                  </div>
-                <% end %>
-                <div class="mask">
-                  <h2><%= link_to following_case.title, following_case, :class => "info2" %></h2>
-                </div>
-              </div>
-          </div>
-        <% end %>
+        <%= render partial: 'cases/thumbnail', layout: 'cases/show_thumbnail', collection: @cases, as: :this_case %>
       </div>
     </div>
 <!-- ROW END -->


### PR DESCRIPTION
Adds partials to render case thumbnails on agency and user show views and does minor refactoring. 

This also includes code to skip using Bullet for `users#show`.  If Bullet is enabled, then it will complain that we should use eager loading to retrieve the state for each case.  However, doing so is not currently possible given the configuration of users, cases, and states - we'd need to change that in a sense, and that's not the point of this PR.  Hence, a filter applied to only that controller.
