### PR TITLE
Adds lograge gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -173,3 +173,5 @@ gem 'rubocop', '~> 0.58', require: false
 gem 'activerecord-session_store'
 
 gem 'auto_strip_attributes', '~> 2.5'
+
+gem 'lograge'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -426,6 +426,11 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
+    lograge (0.11.1)
+      actionpack (>= 4)
+      activesupport (>= 4)
+      railties (>= 4)
+      request_store (~> 1.0)
     loofah (2.2.3)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -770,6 +775,7 @@ DEPENDENCIES
   jquery-turbolinks (~> 2.1)
   kaminari
   launchy (~> 2.4)
+  lograge
   mailboxer (~> 0.12)!
   mini_magick
   mock_redis

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -49,7 +49,7 @@ Rails.application.configure do
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.
-  config.log_level = :debug
+  # config.log_level = :debug
 
   # Prepend all log lines with the following tags.
   # config.log_tags = [ :subdomain, :uuid ]
@@ -75,8 +75,6 @@ Rails.application.configure do
   # Send deprecation notices to registered listeners.
   config.active_support.deprecation = :notify
 
-  # Use default logging formatter so that PID and timestamp are not suppressed.
-  config.log_formatter = ::Logger::Formatter.new
 
   # Do not dump schema after migrations.
   config.active_record.dump_schema_after_migration = false
@@ -92,4 +90,17 @@ Rails.application.configure do
   }
 
   config.middleware.use Rack::HostRedirect, 'ebwiki.herokuapp.com' => 'ebwiki.org'
+
+  # Settings for logging in production
+  config.lograge.enabled = true
+  config.lograge.custom_options = lambda do |event|
+    { time: Time.now }
+  end
+
+  config.lograge.custom_payload do |controller|
+    {
+      host: controller.request.host,
+      user_id: controller.current_user.try(:id)
+    }
+  end
 end


### PR DESCRIPTION
Adds lograge gem and updates production config file to use lograge instead of default logger.  Note that lograge is configured to include a timestamp, the host, and a user_id (if applicable) for each request.  If desired, lograge can be configured to save the output of the default Rails logger in a separate log file.

Overall, I believe that using lograge will simplify debugging in the log run.  lograge replaces the standard Rails default logging output, which is usually several lines, with a single line output.  It doesn't do this for exceptions, which will make it easier to note those as well in production logs.

In your PR did you:

  - [X] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [X] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
