### PR TITLE
Removes heroku deflate gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -103,9 +103,6 @@ gem 'carrierwave', '~> 1.3'
 # image optimizer that works with carrierwave
 gem 'carrierwave-imageoptimizer'
 
-# allow deflated assets with heroku
-gem 'heroku_rails_deflate', groups: %i[production staging]
-
 # CMS panel for admin
 gem 'rails_admin', '~> 1.3.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -382,10 +382,6 @@ GEM
       tilt
     hashdiff (0.3.9)
     hashie (3.6.0)
-    heroku_rails_deflate (1.0.3)
-      actionpack (>= 3.2.13)
-      activesupport (>= 3.2.13)
-      rack (>= 1.4.5)
     hightop (0.2.0)
       activerecord
     http-cookie (1.0.3)
@@ -774,7 +770,6 @@ DEPENDENCIES
   gotcha (= 0.0.6)
   groupdate (~> 4.0)
   guard-rspec (~> 4.7)
-  heroku_rails_deflate
   hightop (~> 0.2)
   httparty (~> 0.16)
   jb (~> 0.5.0)

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = true
+  config.public_file_server.enabled = true
 
   # Compress JavaScripts and CSS.
   config.assets.compress = true


### PR DESCRIPTION
Removes heroku deflate gem - no longer necessary when using updated stack in Heroku.  Changes deprecated configuration for static files in staging.
