### PR TITLE
Replaces sass-rails with sassc-rails due to gem deprecation.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'rails', '~> 5.0.7.2'
 # Use postgresql as the database for Active Record
 gem 'pg', '0.20.0'
 # Use SCSS for stylesheets
-gem 'sass-rails', '~> 5.0'
+gem 'sassc-rails', '~> 2.1'
 # Use Uglifier as compressor for JavaScript assets
 gem 'uglifier', '4.1'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -650,6 +650,12 @@ GEM
     sassc (2.0.1)
       ffi (~> 1.9)
       rake
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     sdoc (1.0.0)
       rdoc (>= 5.0)
     searchkick (3.1.3)
@@ -803,7 +809,7 @@ DEPENDENCIES
   rollbar (~> 2.16)
   rspec-rails (~> 3.8)
   rubocop (~> 0.67)
-  sass-rails (~> 5.0)
+  sassc-rails (~> 2.1)
   sdoc (~> 1.0)
   searchkick (~> 3.1)
   select2-rails (~> 4.0)


### PR DESCRIPTION
This change will replace the `sass-rails` gem with the `sassc-rails` gem.  As noted [here](https://github.com/sass/ruby-sass), the original Ruby implementation of Sass has been deprecated and EOL was in March.  The `sass-rails` gem is supposed to get an upgrade to `sassc`, but it's unclear when that will happen, so the change to the gem was made.  The only other gem we have that depends on `sass-rails` is `rails_admin`, but based on [this](https://github.com/sferik/rails_admin/pull/3072) it's unclear when or if that change will occur.

Edit: Actually, it should be noted that `rails_admin` has been updated to use `sassc-rails` as part of 2.0.0.rc - as such, we will wait for the official release of version 2 before upgrading that gem.

In your PR did you:

  - [ ] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [X] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
