### PR TITLE
Fix case date validation

### DIFF
--- a/app/inputs/date_picker_input.rb
+++ b/app/inputs/date_picker_input.rb
@@ -43,11 +43,11 @@ class DatePickerInput < SimpleForm::Inputs::StringInput
   end
 
   def display_pattern
-    I18n.t('datepicker.dformat', default: '%m/%d/%Y')
+    I18n.t('datepicker.dformat', default: '%d/%m/%Y')
   end
 
   def picker_pattern
-    I18n.t('datepicker.pformat', default: 'MM/DD/YYYY')
+    I18n.t('datepicker.pformat', default: 'DD/MM/YYYY')
   end
 
   def date_view_header_format

--- a/app/inputs/datetime_picker_input.rb
+++ b/app/inputs/datetime_picker_input.rb
@@ -10,7 +10,7 @@ class DatetimePickerInput < DatePickerInput
   end
 
   def picker_pattern
-    I18n.t('datepicker.pformat', default: 'MM/DD/YYYY') + ' ' +
+    I18n.t('datepicker.pformat', default: 'DD/MM/YYYY') + ' ' +
       I18n.t('timepicker.pformat', default: 'HH:mm')
   end
 end

--- a/app/views/cases/_form.html.erb
+++ b/app/views/cases/_form.html.erb
@@ -127,7 +127,9 @@
 <% end %>
 
 <script type="text/javascript">
-  $('.datetimepicker').datetimepicker();
+  $('.datetimepicker').datetimepicker(
+  	format: 'MM-DD-YYYY'
+  	);
   $('input[id=lefile_article]').change(function() {
   	$('#photoCover_article').val(_.last($(this).val().split("\\")));
   });

--- a/app/views/cases/_form.html.erb
+++ b/app/views/cases/_form.html.erb
@@ -127,9 +127,7 @@
 <% end %>
 
 <script type="text/javascript">
-  $('.datetimepicker').datetimepicker(
-  	format: 'MM-DD-YYYY'
-  	);
+  $('.datetimepicker').datetimepicker();
   $('input[id=lefile_article]').change(function() {
   	$('#photoCover_article').val(_.last($(this).val().split("\\")));
   });


### PR DESCRIPTION
This PR reverts previous changes to make the datepicker default to the MM-DD-YYYY format.  For whatever reason, I am unable to change the format of the input data, so even if the date is inputted in the MM-DD-YYYY format, the app reads the data as DD-MM-YYYY.  Future changes to this form will change this field entirely.