### PR TITLE
Changes the session store to the active record session store gem.

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -2,4 +2,4 @@
 
 # Be sure to restart your server when you modify this file.
 
-Rails.application.config.session_store :cookie_store, key: '_eb_wiki_session'
+Rails.application.config.session_store :active_record_store, key: '_eb_wiki_session'


### PR DESCRIPTION
Looks like the Rails upgrade overwrote the initializer to use the cookie store as default.  This restores that setting back to using the `activerecord_session_store` gem.