### PR TITLE
Adds initializer file to hold strftime formats

### DIFF
--- a/app/helpers/analytics_helper.rb
+++ b/app/helpers/analytics_helper.rb
@@ -15,7 +15,7 @@ module AnalyticsHelper
   end
 
   def comment_created_at(comment)
-    comment.created_at.strftime('%B %d, %Y')
+    comment.created_at.to_s(:long)
   end
 
   def link_to_comment(comment, length)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -49,7 +49,7 @@ module ApplicationHelper
   end
 
   def display_updated_at(object)
-    object.updated_at.strftime('%m.%e, %l:%M %p')
+    object.updated_at.to_s(:stamp)
   end
 
   def link_to_case_title(this_case, length)

--- a/app/helpers/cases_helper.rb
+++ b/app/helpers/cases_helper.rb
@@ -17,8 +17,4 @@ module CasesHelper
   def link_to_case_title(this_case, length)
     link_to truncate(this_case.title, length: length), this_case
   end
-
-  def case_updated_at(this_case)
-    this_case.updated_at.strftime('%m.%e,%l:%M %p')
-  end
 end

--- a/app/models/date_range.rb
+++ b/app/models/date_range.rb
@@ -10,7 +10,7 @@ class DateRange
   end
 
   def to_s
-    "from #{start_date.strftime('%b %d, %Y')} to #{end_date.strftime('%b %d, %Y')}"
+    "from #{start_date.to_s(:short_date)} to #{end_date.to_s(:short_date)}"
   end
 
   # rubocop:disable Style/RedundantSelf

--- a/app/views/cases/_thumbnail.html.erb
+++ b/app/views/cases/_thumbnail.html.erb
@@ -11,6 +11,6 @@
   </div>
   <div class="mask">
     <h2><%= link_to this_case.title, this_case, :class => "info2" %></h2>
-    <h5><%= this_case.date.strftime("%B %d, %Y") %> - <%= this_case.city %>, <%= this_case.state.ansi_code %></h5>
+    <h5><%= this_case.date.to_s(:long) %> - <%= this_case.city %>, <%= this_case.state.ansi_code %></h5>
   </div>
 </div>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -36,7 +36,7 @@
       <h1 class="page-header case-title"><%= @subjects.first.name %>, <%= @subjects.first.age ? "#{@subjects.first.age}" : "" %>
       <br>
           <small><%= @this_case.city %>, <%= @this_case.state.name %></small>
-      <br/><small><%= @this_case.date.strftime("%B %d, %Y") %></small>
+      <br/><small><%= @this_case.date.to_s(:long) %></small>
           <% if @this_case.agencies.present? %>
             <p>Agencies:
               <% @this_case.agencies.each_with_index do |agency, index| %>
@@ -84,7 +84,7 @@
             <ul class="background-links" id="link-list">
               <% @this_case.links.each do |link| %>
                 <li>
-                  <%= link_to link.url, "#{link.url}", target: '_blank' %> <span class="timeAgo">added <%= link.created_at.strftime("%b %d, %Y") %></span>
+                  <%= link_to link.url, "#{link.url}", target: '_blank' %> <span class="timeAgo">added <%= link.created_at.to_s(:long) %></span>
                 </li>
               <% end %>
             </ul>

--- a/app/views/conversations/_conversation.html.erb
+++ b/app/views/conversations/_conversation.html.erb
@@ -6,7 +6,7 @@
     <h4 class="media-heading">
       <%= conversation.originator.name %> <br>
       <small><b>Subject: </b><%= conversation.subject %></small><br>
-      <small><b>Date: </b><%=  conversation.messages.last.created_at.strftime("%A, %b %d, %Y at %I:%M%p") %></small>
+      <small><b>Date: </b><%=  conversation.messages.last.created_at.to_s(:stamp) %></small>
     </h4>
     <%= truncate conversation.messages.last.body, length: 145 %>
     <%= link_to "View", conversation_path(conversation) %>

--- a/app/views/conversations/_messages.html.erb
+++ b/app/views/conversations/_messages.html.erb
@@ -9,7 +9,7 @@
         <h4 class="media-heading">
           <%= message.sender.name %> <br>
           <small><b>Subject: </b><%= message.subject %></small><br>
-          <small><b>Date: </b><%=  message.created_at.strftime("%A, %b %d, %Y at %I:%M%p") %></small>
+          <small><b>Date: </b><%=  message.created_at.to_s(:stamp) %></small>
         </h4>
         <%= message.body %>
       </div>

--- a/config/initializers/time_formats.rb
+++ b/config/initializers/time_formats.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+Date::DATE_FORMATS[:short_date] = '%b %e, %Y' #Aug 21, 2019
+Date::DATE_FORMATS[:stamp] = '%A, %b %e, %Y at %l:%M %p' #Wednesday, Aug 21, 2019 at 3:29 PM
+Time::DATE_FORMATS[:stamp] = '%A, %b %e, %Y at %l:%M %p' #Wednesday, Aug 21, 2019 at 3:29 PM

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 describe DateRange do
   it 'should return a string representing the date object' do
-    start_date = 5.days.ago
-    end_date = 2.days.ago
+    start_date = 5.days.ago.beginning_of_day
+    end_date = 2.days.ago.end_of_day
     date = DateRange.new(start_date: start_date, end_date: end_date)
     expect(date.to_s).to eq "from #{start_date.to_s(:short_date)} to #{end_date.to_s(:short_date)}"
   end

--- a/spec/models/date_range_spec.rb
+++ b/spec/models/date_range_spec.rb
@@ -7,7 +7,7 @@ describe DateRange do
     start_date = 5.days.ago
     end_date = 2.days.ago
     date = DateRange.new(start_date: start_date, end_date: end_date)
-    expect(date.to_s).to eq "from #{start_date.strftime('%b %d, %Y')} to #{end_date.strftime('%b %d, %Y')}"
+    expect(date.to_s).to eq "from #{start_date.to_s(:short_date)} to #{end_date.to_s(:short_date)}"
   end
 
   it 'should mark date ranges with the same dates as equal' do


### PR DESCRIPTION
Adds initializer file to hold strftime formats and uses shorthand in views and models for clarity.   Also modifies the formats for readability (e.g., %d -> %e). Removes unused method from cases helper.

In your PR did you:

  - [X] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [X] Add and/or update specs for your code?
