### PR TITLE
Adds cause of death enum

### DIFF
--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -5,6 +5,17 @@
 class Case < ApplicationRecord
   # TODO: Clean up relationship section
 
+  enum cause_of_death_name: {
+    choking: 'choking',
+    shooting: 'shooting',
+    beating: 'beating',
+    taser: 'taser',
+    vehicular: 'vehicular',
+    medical_neglect: 'medical neglect',
+    response_to_medical_emergency: 'response to medical emergency',
+    suicide: 'suicide'
+  }
+
   belongs_to :user
   belongs_to :cause_of_death
   belongs_to :state

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -2,6 +2,7 @@
 
 # This is the main model of the application. Each death is a case.
 # TODO: Lots & lots of refactoring
+# rubocop:disable Metrics/ClassLength
 class Case < ApplicationRecord
   # TODO: Clean up relationship section
 
@@ -140,3 +141,4 @@ class Case < ApplicationRecord
     ]
   end
 end
+# rubocop:enable Metrics/ClassLength

--- a/db/migrate/20190824175709_add_cause_of_death_to_postgres.rb
+++ b/db/migrate/20190824175709_add_cause_of_death_to_postgres.rb
@@ -1,0 +1,17 @@
+class AddCauseOfDeathToPostgres < ActiveRecord::Migration[5.0]
+  def up
+    execute <<-SQL
+      CREATE TYPE cause_of_death AS ENUM ('choking', 'shooting', 'beating', 'taser', 'vehicular', 'medical neglect', 'response to medical emergency', 'suicide')
+    SQL
+
+    add_column :cases, :cause_of_death, :cause_of_death, index: true
+  end
+
+  def down
+    remove_column :cases, :cause_of_death
+
+    execute <<-SQL
+      DROP TYPE cause_of_death;
+    SQL
+  end
+end

--- a/db/migrate/20190825000337_rename_cause_of_death_for_cases.rb
+++ b/db/migrate/20190825000337_rename_cause_of_death_for_cases.rb
@@ -1,0 +1,5 @@
+class RenameCauseOfDeathForCases < ActiveRecord::Migration[5.0]
+  def change
+    rename_column :cases, :cause_of_death, :cause_of_death_name
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -30,6 +30,22 @@ COMMENT ON EXTENSION plpgsql IS 'PL/pgSQL procedural language';
 
 
 --
+-- Name: cause_of_death; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.cause_of_death AS ENUM (
+    'choking',
+    'shooting',
+    'beating',
+    'taser',
+    'vehicular',
+    'medical neglect',
+    'response to medical emergency',
+    'suicide'
+);
+
+
+--
 -- Name: jurisdiction; Type: TYPE; Schema: public; Owner: -
 --
 
@@ -276,7 +292,8 @@ CREATE TABLE public.cases (
     summary text NOT NULL,
     follows_count integer DEFAULT 0 NOT NULL,
     default_avatar_url character varying,
-    blurb text
+    blurb text,
+    cause_of_death_name public.cause_of_death
 );
 
 
@@ -1961,6 +1978,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190406032344'),
 ('20190420191754'),
 ('20190422003442'),
-('20190815012327');
+('20190815012327'),
+('20190824175709'),
+('20190825000337');
 
 

--- a/lib/tasks/cases.rake
+++ b/lib/tasks/cases.rake
@@ -15,4 +15,16 @@ namespace :cases do
     end
     # rubocop:enable LineLength
   end
+
+  desc 'Convert cause of death to enum'
+  task convert_cause_of_death: :environment do
+    causes_of_death = CauseOfDeath.where.not(name: 'Unknown').pluck(:id, :name).to_h
+    lookup = causes_of_death.map { |k, v| [k, v.downcase.parameterize(separator: '_').to_sym] }.to_h
+
+    lookup.each do |k, v|
+      Case.where(cause_of_death_id: k).in_batches do |group|
+        group.update_all(cause_of_death_name: v)
+      end
+    end
+  end
 end

--- a/spec/lib/tasks/cases_rake_spec.rb
+++ b/spec/lib/tasks/cases_rake_spec.rb
@@ -12,3 +12,18 @@ describe 'cases:add_blurb' do
     end
   end
 end
+
+describe 'cases:convert_cause_of_death' do
+  include_context 'rake'
+
+  let(:_case) { create(:case) }
+  let(:cod) {  CauseOfDeath.create(name: 'Shooting') }
+
+  it 'converts cause of death from reference to enum' do
+    _case.update_attribute :cause_of_death_id, cod.id
+    subject.invoke
+    _case.reload
+    name = cod.name.downcase.parameterize(separator: '_')
+    expect(_case.cause_of_death_name).to eq name
+  end
+end


### PR DESCRIPTION
Adds migration to create cause of death enum.  Adds rake task to convert cause of death reference data on case table to enum.

Addresses Issue #3005 in part

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [X] Include screenshots of any changes to the UI?
  - [X] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [X] Add and/or update specs for your code?
