### PR TITLE
Changes case controller and form to use cause of death enum

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -128,7 +128,7 @@ class CasesController < ApplicationController
                                   :litigation,
                                   :community_action,
                                   :agency_id,
-                                  :cause_of_death_id,
+                                  :cause_of_death_name,
                                   :date,
                                   :state_id,
                                   :city,

--- a/app/views/cases/_form.html.erb
+++ b/app/views/cases/_form.html.erb
@@ -37,7 +37,7 @@
 				<h4>Add a YouTube or Vimeo video url relating to the case:</h4>
 				<%= f.input :video_url %>
 				<h4>Cause of death:</h4>
-				<%= f.collection_select :cause_of_death_id, @causes_of_death, :id, :name, {prompt: "Choose a cause of death."} %>
+				<%= f.input :cause_of_death_name, collection: [:choking, :shooting, :beating, :taser, :vehicular, :medical_neglect, :response_to_medical_emergency, :suicide], label: false %>
 	    </div>
 		</fieldset>
 	</div>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -19,6 +19,16 @@ en:
           federal: 'Federal'
           university: 'University'
           commercial: 'Commercial'
+      case:
+        cause_of_death_name:
+          choking: 'Choking'
+          shooting: 'Shooting'
+          beating: 'Beating'
+          taser: 'Taser'
+          vehicular: 'Vehicular'
+          medical_neglect: 'Medical Neglect'
+          response_to_medical_emergency: 'Response to Medical Emergency'
+          suicide: 'Suicide'
     labels:
       agency:
         state: 'State'


### PR DESCRIPTION
Changes case controller and form to use cause of death enum instead of model.

Addresses Issue #3005 in part.  Screenshot attached.

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [X] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
