### PR TITLE
Fixes unknown host issue for link in user notifier email.  Adds maile…

### DIFF
--- a/app/views/user_notifier/send_followers_email.html.erb
+++ b/app/views/user_notifier/send_followers_email.html.erb
@@ -1,6 +1,6 @@
 <h1> **ALERT** <%= @this_case.title %> update:</h1>
 <p>Case editor <%= User.find(@this_case.versions.last.whodunnit).name %>
-has updated the <%= link_to @this_case.title, @this_case %> case on EBWiki today. To describe the update,
+has updated the <%= link_to @this_case.title, url_for(@this_case) %> case on EBWiki today. To describe the update,
  <%= User.find(@this_case.versions.last.whodunnit).name %> says: "<%= @this_case.versions.last.comment%>".
 <p>
 <p> Please feel free to add any data you have on this or <%= link_to 'other cases', 'http://ebwiki.org' %>.</p>

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Preview all emails at http://localhost:3000/mailers/admin_mailer
+# Preview all emails at http://localhost:3000/rails/mailers/admin_mailer
 class AdminMailerPreview < ActionMailer::Preview
   def new_admin_email
     AdminMailer.new_admin_email(user: User.find_by(admin: true), recipients: User.last.pluck(:email))

--- a/spec/mailers/previews/user_notifier_preview.rb
+++ b/spec/mailers/previews/user_notifier_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/user_notifier
+class UserNotifierPreview < ActionMailer::Preview
+  def send_followers_email
+    UserNotifier.send_followers_email([User.first], Case.last)
+  end
+end


### PR DESCRIPTION
Fixes unknown host issue for link in user notifier email.  Adds mailer preview for user notifier, and updates link to see previews.

There's not an issue to directly link to, as this bug only pops up when sending followers an email on an update.  Additionally, there's only a mailer preview for this specific action - other previews and specs will be added in a separate PR.

In your PR did you:

  - [X] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [X] Add and/or update specs for your code?
