### PR TITLE
Changed find method & removed conditional statement

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -86,9 +86,9 @@ class CasesController < ApplicationController
   end
 
   def history
-    @this_case = Case.friendly.find_by_slug(params[:case_slug])
+    @this_case = Case.friendly.find(params[:case_slug])
     @case_history = @this_case.try(:versions).order(created_at: :desc) unless
-    @this_case.blank? || @this_case.versions.blank?
+    @this_case.versions.blank?
   rescue ActiveRecord::RecordNotFound
   end
 


### PR DESCRIPTION
Fix #3206: changed find method in case history action from `find_by_slug` to `find` and removed `this_case.blank?` from conditional statements.
