### PR TITLE
Disables include blank option for cause of death dropdown

### DIFF
--- a/app/views/cases/_form.html.erb
+++ b/app/views/cases/_form.html.erb
@@ -37,7 +37,7 @@
 				<h4>Add a YouTube or Vimeo video url relating to the case:</h4>
 				<%= f.input :video_url %>
 				<h4>Cause of death:</h4>
-				<%= f.input :cause_of_death_name, collection: [:choking, :shooting, :beating, :taser, :vehicular, :medical_neglect, :response_to_medical_emergency, :suicide], label: false %>
+				<%= f.input :cause_of_death_name, collection: [:choking, :shooting, :beating, :taser, :vehicular, :medical_neglect, :response_to_medical_emergency, :suicide], label: false, include_blank: false %>
 	    </div>
 		</fieldset>
 	</div>


### PR DESCRIPTION
Disables include blank option for cause of death dropdown so selection is always displayed.
