### PR TITLE
Remove all rubocop long line warnings #3204

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # EBWiki
 
-[EBWiki.org](http://ebwiki.org) is a site dedicated to documenting instances where people of color are killed by law enforcement officers during routine interactions.  
+[EBWiki.org](http://ebwiki.org) is a site dedicated to documenting instances where people of color are killed by law enforcement officers during routine interactions.
 
 ## Motivation
 
@@ -14,9 +14,9 @@ Our idea, EBWiki, is designed to highlight not only the original incident betwee
 
 All developers are welcome to contribute to the codebase.  For general information on contributing, consult [this guide](docs/DEVELOPMENT.md) on developing for EBWiki.
 
-We ask that, if possible, you address issues that are labelled `quick fix` first, followed by those marked as `high priority`.  
+We ask that, if possible, you address issues that are labelled `quick fix` first, followed by those marked as `high priority`.
 
-Additionally, take care to note when an issue is one of several (e.g., 1 of 7, 2 of 3, etc).  Those issues are part of a project or milestone (indicated on the right side under the label), and clicking on the project or milestone should take you to a list of all of the issues.  Please note that those must be completed and merged in order.   
+Additionally, take care to note when an issue is one of several (e.g., 1 of 7, 2 of 3, etc).  Those issues are part of a project or milestone (indicated on the right side under the label), and clicking on the project or milestone should take you to a list of all of the issues.  Please note that those must be completed and merged in order.
 
 If this is your first open source contribution, welcome!  We're glad that you chose to get started with us.  You can find some good first issues labelled exactly that, `good first issue`.
 
@@ -24,7 +24,7 @@ All contributors are expected to adhere to our code of conduct, which can be fou
 
 ### Development
 
-Instructions on setting up a local development environment can be found [here](docs/SETUP_LOCALLY.md).  
+Instructions on setting up a local development environment can be found [here](docs/SETUP_LOCALLY.md).
 
 In general, contributors will use the following languages, frameworks, and technologies:
 
@@ -45,7 +45,7 @@ We use [RSpec](https://github.com/rspec/rspec-rails), [shoulda-matchers](http://
 rspec spec/
 ```
 
-More information on how to use RSpec, shoulda-matchers, and FactoryBot can be found at the links above.  
+More information on how to use RSpec, shoulda-matchers, and FactoryBot can be found at the links above.
 
 We also use [Rubocop](https://github.com/bbatsov/rubocop) as part of our continous integration process in Travis.  To run Rubocop locally, enter
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -68,7 +68,11 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: [:name])
     devise_parameter_sanitizer.permit(:account_update, keys: [:name])
-    devise_parameter_sanitizer.permit(:sign_up) { |u| u.permit(:name, :description, :subscribed, :email, :password, :password_confirmation) }
-    devise_parameter_sanitizer.permit(:account_update) { |u| u.permit(:name, :description, :subscribed, :email, :password, :password_confirmation) }
+    devise_parameter_sanitizer.permit(:sign_up) do |u|
+      u.permit(:name, :description, :subscribed, :email, :password, :password_confirmation)
+    end
+    devise_parameter_sanitizer.permit(:account_update) do |u|
+      u.permit(:name, :description, :subscribed, :email, :password, :password_confirmation)
+    end
   end
 end

--- a/app/helpers/user_notifier_helper.rb
+++ b/app/helpers/user_notifier_helper.rb
@@ -2,13 +2,9 @@
 
 # Set of helper methods for composing email messages
 module UserNotifierHelper
-  FOLLOW_CALL_TO_ACTION = <<~"FCTA"
-    It is very important that you click to follow one or more cases and allow us to keep
-    you up to date. The more people paying attention, the easier it will be to affect change.
-  FCTA
+  FOLLOW_CALL_TO_ACTION = I18n.t 'notifier.follow_cases'
 
-  SUBSCRIBER_MESSAGE = "As a newsletter subscriber, you'll \
-    receive our general updates periodically."
+  SUBSCRIBER_MESSAGE = I18n.t 'notifier.subscribe_message'
 
   subscriber_link_copy = 'Subscribe to our newsletter as well'
   subscriber_link = ActionController::Base.helpers.link_to(

--- a/app/jobs/application_job.rb
+++ b/app/jobs/application_job.rb
@@ -1,2 +1,4 @@
+# frozen_string_literal: true
+
 class ApplicationJob < ActiveJob::Base
 end

--- a/app/mailers/user_notifier.rb
+++ b/app/mailers/user_notifier.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+# Manages email notifications for users
 class UserNotifier < ApplicationMailer
   helper UserNotifierHelper
 

--- a/app/mailers/user_notifier.rb
+++ b/app/mailers/user_notifier.rb
@@ -8,7 +8,7 @@ class UserNotifier < ApplicationMailer
   def send_followers_email(users, this_case)
     @this_case = this_case
     users.each do |user|
-      Rails.logger.info("UserNotifier#send_followers_email: Sending notification to #{user.email} about case #{this_case.title}")
+      Rails.logger.info(I18n.t('notifier.followers_email_text', user.email, this_case.title))
       mail(to: user.email, subject: "The #{@this_case.title} case has been updated on EBWiki.")
     end
   end
@@ -16,7 +16,7 @@ class UserNotifier < ApplicationMailer
   def send_deletion_email(users, this_case)
     @this_case = this_case
     users.each do |user|
-      Rails.logger.info("UserNotifier#send_deletion_email: Sending notification to #{user.email} about case #{this_case.title}")
+      Rails.logger.info(I18n.t('notifier.deletion_email_text', user.email, this_case.title))
       mail(to: user.email, subject: "The #{@this_case.title} case has been removed from EBWiki")
     end
   end

--- a/app/services/sort_collection_ordinally.rb
+++ b/app/services/sort_collection_ordinally.rb
@@ -6,7 +6,9 @@ class SortCollectionOrdinally
   include Service
 
   def call(collection:, column_name: 'name')
-    first_sort = collection.sort_by { |e| ActiveSupport::Inflector.transliterate(e.send(column_name).downcase) }
+    first_sort = collection.sort_by do |e|
+      ActiveSupport::Inflector.transliterate(e.send(column_name).downcase)
+    end
     names_with_numbers = first_sort.select { |element| element.send(column_name).match(/(\d+)/) }
     return first_sort if names_with_numbers.empty?
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -27,7 +27,8 @@ Rails.application.configure do
   # Do not fallback to assets pipeline if a precompiled asset is missed.
   config.assets.compile = false
 
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+  # `config.assets.precompile` and `config.assets.version` have moved to
+  # config/initializers/assets.rb
 
   # Enable serving of images, stylesheets, and JavaScripts from an asset server.
   # config.action_controller.asset_host = 'http://assets.example.com'

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -38,7 +38,8 @@ Rails.application.configure do
   # yet still be able to expire them through the digest params.
   config.assets.digest = true
 
-  # `config.assets.precompile` and `config.assets.version` have moved to config/initializers/assets.rb
+  # `config.assets.precompile` and `config.assets.version`
+  # have moved to config/initializers/assets.rb
 
   # Specifies the header that your server uses for sending files.
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -6,7 +6,8 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  config.secret_key = '668a27b66add557bcdaaabe23439b30e58b17a1fcc011f4a5a6c0cb0d4f7652d588ecf60cd9c0a038ef9204819c112e16b38b90ca08d45ddf770f39427a7cb04'
+  config.secret_key = '668a27b66add557bcdaaabe23439b30e58b17a1fcc011f4a5a6c0\
+  cb0d4f7652d588ecf60cd9c0a038ef9204819c112e16b38b90ca08d45ddf770f39427a7cb04'
 
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,

--- a/config/initializers/ranged_datetime_wrapper.rb
+++ b/config/initializers/ranged_datetime_wrapper.rb
@@ -1,7 +1,10 @@
 # frozen_string_literal: true
 
 SimpleForm.setup do |config|
-  config.wrappers :ranged_datetime, tag: 'div', class: 'form-group col-md-6', error_class: 'has-error' do |b|
+  config.wrappers :ranged_datetime,
+                  tag: 'div',
+                  class: 'form-group col-md-6',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :readonly

--- a/config/initializers/redis.rb
+++ b/config/initializers/redis.rb
@@ -2,8 +2,11 @@
 
 # config/initializers/redis.rb
 
-if Rails.env.test?
-  $redis = Redis::Namespace.new('ebwiki', redis: MockRedis.new)
-else
-  $redis = Redis::Namespace.new('ebwiki', redis: Redis.new(host: ENV['REDISTOGO_URL'] || 'localhost', port: 6379, db: 0))
-end
+$redis = if Rails.env.test?
+           Redis::Namespace.new('ebwiki', redis: MockRedis.new)
+         else
+           Redis::Namespace.new('ebwiki',
+                                redis: Redis.new(host: ENV['REDISTOGO_URL'] || 'localhost',
+                                                 port: 6379,
+                                                 db: 0))
+         end

--- a/config/initializers/simple_form_bootstrap.rb
+++ b/config/initializers/simple_form_bootstrap.rb
@@ -20,7 +20,10 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_file_input,
+                  tag: 'div',
+                  class: 'form-group',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -32,7 +35,10 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_boolean,
+                  tag: 'div',
+                  class: 'form-group',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -44,7 +50,10 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :vertical_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :vertical_radio_and_checkboxes,
+                  tag: 'div',
+                  class: 'form-group',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.optional :readonly
     b.use :label, class: 'control-label'
@@ -53,7 +62,10 @@ SimpleForm.setup do |config|
     b.use :hint,  wrap_with: { tag: 'p', class: 'help-block' }
   end
 
-  config.wrappers :horizontal_form, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_form,
+                  tag: 'div',
+                  class: 'form-group',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -69,7 +81,10 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_file_input, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_file_input,
+                  tag: 'div',
+                  class: 'form-group',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.use :placeholder
     b.optional :maxlength
@@ -83,7 +98,10 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_boolean, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_boolean,
+                  tag: 'div',
+                  class: 'form-group',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.optional :readonly
 
@@ -97,7 +115,10 @@ SimpleForm.setup do |config|
     end
   end
 
-  config.wrappers :horizontal_radio_and_checkboxes, tag: 'div', class: 'form-group', error_class: 'has-error' do |b|
+  config.wrappers :horizontal_radio_and_checkboxes,
+                  tag: 'div',
+                  class: 'form-group',
+                  error_class: 'has-error' do |b|
     b.use :html5
     b.optional :readonly
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -35,3 +35,15 @@ en:
     vimeo_helper_url: "https://vimeo.com/136536466"
     youtube_iframe_url: '<iframe src="//www.youtube.com/embed/Mgn1r3_eM-s"></iframe>'
     vimeo_iframe_url: '<iframe src="https://player.vimeo.com/video/136536466"></iframe>'
+  notifier:
+    follow_cases: "It is very important that you click to follow one or more cases and allow us to keep you up to date. The more people paying attention, the easier it will be to affect change."
+    subscribe_message: "As a newsletter subscriber, you'll receive our general updates periodically."
+    mail_body: "You have already taken the first step by following 1 case on EBWiki and allowing us to keep you up to date."
+    confirmation_message: "Thanks for signing up for EBWiki, click here to confirm your account."
+    followers_email_text: 'UserNotifier#send_followers_email: Sending notification to %{email} about case %{title}'
+    deletion_email_text: 'UserNotifier#send_deletion_email: Sending notification to %{email} about case %{title}'
+    call_to_action: '%{link} for periodic general updates and commentaries on this issue.'
+    subscribe: "Subscribe to our newsletter as well"
+  presenter:
+    test_query: "Your search for \"%{query}\" has returned 1 result."
+    test_state: "Your search for cases in %{state} has returned 1 result."

--- a/spec/helpers/user_notifier_helper_spec.rb
+++ b/spec/helpers/user_notifier_helper_spec.rb
@@ -3,12 +3,16 @@
 require 'rails_helper'
 
 RSpec.describe UserNotifierHelper, type: :helper do
-  let(:user)                      { FactoryBot.create(:user) }
-  let(:this_case)                 { FactoryBot.create(:case) }
-  let(:follow_call_to_action)     { "It is very important that you click to follow one or more cases and allow us to keep\nyou up to date. The more people paying attention, the easier it will be to affect change.\n" }
-  let(:follow_message)            { 'You have already taken the first step by following 1 case on EBWiki and allowing us to keep you up to date.' }
-  let(:subscribe_call_to_action)  { "#{ActionController::Base.helpers.link_to('Subscribe to our newsletter as well', ENV['MAILCHIMP_LINK'])} for periodic general updates and commentaries on this issue." }
-  let(:subscriber_message)        { "As a newsletter subscriber, you'll receive our general updates periodically." }
+  let(:user)                     { FactoryBot.create(:user) }
+  let(:this_case)                { FactoryBot.create(:case) }
+  let(:follow_call_to_action)    { I18n.t 'notifier.follow_cases' }
+  let(:follow_message)           { I18n.t 'notifier.mail_body' }
+  let(:subscriber_message)       { I18n.t 'notifier.subscribe_message' }
+  let(:subscribe_call_to_action) do
+    I18n.t('notifier.call_to_action',
+           link: ActionController::Base.helpers.link_to(I18n.t('notifier.subscribe'),
+                                                        ENV['MAILCHIMP_LINK']))
+  end
 
   describe 'create_welcome_email_message' do
     it 'generates the message for an unsubscribed user with no followed cases' do

--- a/spec/mailers/admin_mailer_spec.rb
+++ b/spec/mailers/admin_mailer_spec.rb
@@ -5,7 +5,7 @@ require 'rails_helper'
 RSpec.describe AdminMailer, type: :mailer do
   describe 'admin mailer' do
     let(:user) { FactoryBot.create(:user, admin: true) }
-    let(:admin) { FactoryBot.create(:user, name: 'A Follower', email: 'admin@ebwiki.org', admin: true) }
+    let(:admin) { FactoryBot.create(:user, name: 'Follower', email: 'admin@test.org', admin: true) }
     let!(:mail) { AdminMailer.new_admin_email(new_admin: user, recipients: [admin.email]) }
 
     it 'renders the subject and receiver email' do

--- a/spec/mailers/previews/admin_mailer_preview.rb
+++ b/spec/mailers/previews/admin_mailer_preview.rb
@@ -3,6 +3,7 @@
 # Preview all emails at http://localhost:3000/rails/mailers/admin_mailer
 class AdminMailerPreview < ActionMailer::Preview
   def new_admin_email
-    AdminMailer.new_admin_email(user: User.find_by(admin: true), recipients: User.last.pluck(:email))
+    AdminMailer.new_admin_email(user: User.find_by(admin: true),
+                                recipients: User.last.pluck(:email))
   end
 end

--- a/spec/mailers/user_notifier_spec.rb
+++ b/spec/mailers/user_notifier_spec.rb
@@ -76,8 +76,10 @@ RSpec.describe UserNotifier, type: :mailer do
 
     it 'renders the proper message when user has followed 1 or more cases' do
       user.follow(this_case)
-      expect(mail.body.encoded.gsub(/\s+/, '')).to include('You have already taken the first step by following 1 case on EBWiki and allowing us to keep you up to date.'.gsub(/\s+/, ''))
-      expect(mail.body.encoded.gsub(/\s+/, '')).not_to include("It is very important that you click to follow one or more cases and allow us to keep\nyou up to date. The more people paying attention, the easier it will be effect change.".gsub(/\s+/, ''))
+      expect(mail.body.encoded.gsub(/\s+/, '')).to include(I18n.t('notifier.mail_body')
+                                                               .gsub(/\s+/, ''))
+      expect(mail.body.encoded.gsub(/\s+/, '')).not_to include(I18n.t('notifier.follow_cases')
+                                                                   .gsub(/\s+/, ''))
     end
   end
 
@@ -93,7 +95,8 @@ RSpec.describe UserNotifier, type: :mailer do
 
     it 'renders the proper message' do
       user.follow(this_case)
-      expect(mail.body.encoded.gsub(/\s+/, '')).to include('Thanks for signing up for EBWiki, click here to confirm your account.'.gsub(/\s+/, ''))
+      expect(mail.body.encoded.gsub(/\s+/, '')).to include(I18n.t('notifier.confirmation_message')
+                                                               .gsub(/\s+/, ''))
     end
   end
 end

--- a/spec/models/agency_spec.rb
+++ b/spec/models/agency_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Agency do
   it do
     FactoryBot.create(:agency)
     should validate_uniqueness_of(:name).ignoring_case_sensitivity
-                                        .with_message('An agency with this name already exists and can be found. If you'\
-                  ' want to create a new agency, it must have a unique name.')
+                                        .with_message('An agency with this name already exists '\
+              'and can be found. If you want to create a new agency, it must have a unique name.')
   end
 
   it 'updates slug if agency title is updated' do

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe Case do
     end
 
     it do
-      should validate_presence_of(:summary).with_message('Please use the last field at the bottom of this form ' \
-             'to summarize your edits to the case.')
+      should validate_presence_of(:summary).with_message('Please use the last field at the ' \
+             'bottom of this form to summarize your edits to the case.')
     end
 
     it do

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -204,7 +204,7 @@ describe '#nearby_cases', versioning: true do
 end
 
 describe '#default_avatar_url', versioning: true do
-  it 'takes the avatar''s default URL and turns this into a column' do
+  it 'takes the avatars default URL and turns this into a column' do
     this_case = FactoryBot.create(:case)
     avatar_mock = double('Avatar', url: 'https://avatar.com')
     allow(this_case).to receive(:default_avatar_url).and_return(avatar_mock.url)

--- a/spec/presenters/search_presenter_spec.rb
+++ b/spec/presenters/search_presenter_spec.rb
@@ -14,7 +14,7 @@ describe SearchPresenter do
                                     state_id: nil,
                                     count: count,
                                     view: view)
-    expect(presenter.search_results_text).to eq "Your search for \"#{query}\" has returned 1 result."
+    expect(presenter.search_results_text).to eq I18n.t('presenter.test_query', query: query)
   end
 
   it 'should create the right text with just a state' do
@@ -22,6 +22,6 @@ describe SearchPresenter do
                                     state_id: state.id,
                                     count: count,
                                     view: view)
-    expect(presenter.search_results_text).to eq "Your search for cases in #{state.name} has returned 1 result."
+    expect(presenter.search_results_text).to eq I18n.t('presenter.test_state', state: state.name)
   end
 end

--- a/spec/support/controller_macros.rb
+++ b/spec/support/controller_macros.rb
@@ -12,7 +12,8 @@ module ControllerMacros
     before(:each) do
       @request.env['devise.mapping'] = Devise.mappings[:user]
       @user = FactoryBot.create(:user)
-      # user.confirm! # or set a confirmed_at inside the factory. Only necessary if you are using the 'confirmable' module
+      # user.confirm! # or set a confirmed_at inside the factory.
+      # Only necessary if you are using the 'confirmable' module
       sign_in @user
     end
   end

--- a/spec/support/shared_contexts/rake.rb
+++ b/spec/support/shared_contexts/rake.rb
@@ -14,7 +14,9 @@ shared_context 'rake' do
 
   before do
     Rake.application = rake
-    Rake.application.rake_require(task_path, [Rails.root.to_s], loaded_files_excluding_current_rake_file)
+    Rake.application.rake_require(task_path,
+                                  [Rails.root.to_s],
+                                  loaded_files_excluding_current_rake_file)
 
     Rake::Task.define_task(:environment)
   end


### PR DESCRIPTION
PR to address #3204 for Hacktoberfest and to remove rubocop warnings about long lines.
- Most use I18n or parameter line breaks
- Some other cases use escaped newlines or do-end blocks
- Some needed more than one technique or just a few characters removed
- I've broken the commits up by technique where possible
- A few other rubocop and whitespace fixes thrown in for free :laughing: 

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [x] Add and/or update specs for your code?
