### PR TITLE
Fix first-time database setup

### DIFF
--- a/db/structure.sql
+++ b/db/structure.sql
@@ -1980,10 +1980,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190422003442'),
 ('20190815012327'),
 ('20190824175709'),
-('20190825000337');
-
-<<<<<<< HEAD
-
-=======
-INSERT INTO schema_migrations (version) VALUES ('20190422003442');
->>>>>>> Update for dev provisions
+('20190825000337'),
+('20190422003442');


### PR DESCRIPTION
https://github.com/EBWiki/EBWiki/commit/603d8af7356a38e4d1544bec85f93e4f5561791d introduced some git conflict artifacts to db/structure.sql, which broke `rake db:setup` (and, presumably, other db setup tasks.) 

Removing the conflict artifacts allows db setup to proceed.
