### PR TITLE
Adds default host option for production environment

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -63,6 +63,7 @@ Rails.application.configure do
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false
+  config.action_mailer.default_url_options = { host: 'ebwiki.org' }
 
   # Enable locale fallbacks for I18n (makes lookups for any locale fall back to
   # the I18n.default_locale when a translation cannot be found).


### PR DESCRIPTION
If we want to include links in emails, then we need to specify the host for ActionView to use.  We can do that in production by setting the default host option for URLs.
