### PR TITLE
Use Devise to confirm user emails

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -25,9 +25,4 @@ class UserMailer < ApplicationMailer
     @user = user
     mail(to: @user.email, subject: 'Welcome to EndBiasWiki')
   end
-
-  def send_confirmation_email(user)
-    @user = user
-    mail(to: @user.email, subject: 'Confirm your email address')
-  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,9 +5,9 @@ require 'observer'
 # EBWiki site user
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable and :omniauthable
+  # :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :trackable, :validatable, :confirmable
 
   validates :name, presence: { message: 'Please add a name.' }
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= "#{I18n.t('greetings.welcome')} #{@email}" %>!</p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= I18n.t('notifier.confirmation_message') %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to I18n.t('notifier.confirmation_cta'), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,4 +1,4 @@
-<p><%= "#{I18n.t('greetings.welcome')} #{@email}" %>!</p>
+<p><%= "#{I18n.t('greetings.welcome')} #{@resource.name}" %>!</p>
 
 <p><%= I18n.t('notifier.confirmation_message') %></p>
 

--- a/app/views/user_notifier/send_confirmation_email.html.erb
+++ b/app/views/user_notifier/send_confirmation_email.html.erb
@@ -1,1 +1,0 @@
-Thanks for signing up for EBWiki, click here to confirm your account.

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -118,7 +118,7 @@ Devise.setup do |config|
   # initial account confirmation) to be applied. Requires additional unconfirmed_email
   # db field (see migrations). Until confirmed, new email is stored in
   # unconfirmed_email column, and copied to email column on successful confirmation.
-  config.reconfirmable = true
+  config.reconfirmable = false
 
   # Defines which key will be used when confirming an account
   # config.confirmation_keys = [ :email ]

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,8 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  greetings:
+    welcome: "Welcome"
   mailboxer:
     message_mailer:
       subject_new: 'You received a new EBWiki message about %{subject}'
@@ -39,7 +41,8 @@ en:
     follow_cases: "It is very important that you click to follow one or more cases and allow us to keep you up to date. The more people paying attention, the easier it will be to affect change."
     subscribe_message: "As a newsletter subscriber, you'll receive our general updates periodically."
     mail_body: "You have already taken the first step by following 1 case on EBWiki and allowing us to keep you up to date."
-    confirmation_message: "Thanks for signing up for EBWiki, click here to confirm your account."
+    confirmation_message: "Thanks for signing up for EBWiki."
+    confirmation_cta: "Click here to confirm your account"
     followers_email_text: 'UserNotifier#send_followers_email: Sending notification to %{email} about case %{title}'
     deletion_email_text: 'UserNotifier#send_deletion_email: Sending notification to %{email} about case %{title}'
     call_to_action: '%{link} for periodic general updates and commentaries on this issue.'

--- a/db/migrate/20191012043517_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20191012043517_add_unconfirmed_email_to_users.rb
@@ -1,0 +1,5 @@
+class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :unconfirmed_email, :string
+  end
+end

--- a/db/migrate/20191012043517_add_unconfirmed_email_to_users.rb
+++ b/db/migrate/20191012043517_add_unconfirmed_email_to_users.rb
@@ -1,5 +1,0 @@
-class AddUnconfirmedEmailToUsers < ActiveRecord::Migration[5.0]
-  def change
-    add_column :users, :unconfirmed_email, :string
-  end
-end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -936,8 +936,7 @@ CREATE TABLE public.users (
     analyst boolean DEFAULT false,
     confirmation_token character varying,
     confirmed_at timestamp without time zone,
-    confirmation_sent_at timestamp without time zone,
-    unconfirmed_email character varying
+    confirmation_sent_at timestamp without time zone
 );
 
 
@@ -1981,6 +1980,4 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190422003442'),
 ('20190815012327'),
 ('20190824175709'),
-('20190825000337'),
-('20190422003442'),
-('20191012043517');
+('20190825000337');

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -936,7 +936,8 @@ CREATE TABLE public.users (
     analyst boolean DEFAULT false,
     confirmation_token character varying,
     confirmed_at timestamp without time zone,
-    confirmation_sent_at timestamp without time zone
+    confirmation_sent_at timestamp without time zone,
+    unconfirmed_email character varying
 );
 
 
@@ -1981,4 +1982,5 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20190815012327'),
 ('20190824175709'),
 ('20190825000337'),
-('20190422003442');
+('20190422003442'),
+('20191012043517');

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -15,6 +15,10 @@ RSpec.describe Devise::Mailer, type: :mailer do
       expect(mail.subject).to eql('Confirmation instructions')
     end
 
+    it 'addresses the user' do
+      expect(mail.body.encoded).to include(user.name)
+    end
+
     it 'is polite' do
       expect(mail.body.encoded).to include('Thanks for signing up for EBWiki')
     end

--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Devise::Mailer, type: :mailer do
+  describe 'send_confirmation_email' do
+    let!(:user) { FactoryBot.create(:user) }
+    let(:mail)  { Devise.mailer.deliveries.last }
+
+    it 'renders the receiver email' do
+      expect(mail.to).to eq([user.email])
+    end
+
+    it 'renders the subject' do
+      expect(mail.subject).to eql('Confirmation instructions')
+    end
+
+    it 'is polite' do
+      expect(mail.body.encoded).to include('Thanks for signing up for EBWiki')
+    end
+
+    it 'prompts the user to confirm' do
+      expect(mail.body.encoded).to match(/click here to confirm your account/i)
+    end
+  end
+end

--- a/spec/mailers/previews/devise_mailer_preview.rb
+++ b/spec/mailers/previews/devise_mailer_preview.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Preview all emails at http://localhost:3000/rails/mailers/devise_mailer
+class DeviseMailerPreview < ActionMailer::Preview
+  def confirmation_instructions
+    Devise::Mailer.confirmation_instructions(User.first, {})
+  end
+end

--- a/spec/mailers/user_mailer_spec.rb
+++ b/spec/mailers/user_mailer_spec.rb
@@ -82,24 +82,4 @@ RSpec.describe UserMailer, type: :mailer do
                                                                    .gsub(/\s+/, ''))
     end
   end
-
-  describe 'send_confirmation_email' do
-    pending
-    let(:user)      { FactoryBot.create(:user) }
-    let(:this_case) { FactoryBot.create(:case) }
-    let!(:mail)     { UserMailer.welcome_email(user: user) }
-
-    it 'renders the subject and receiver email' do
-      pending
-      expect(mail.subject).to eql('Confirm your email address')
-      expect(mail.to).to eq([user.email])
-    end
-
-    it 'renders the proper message' do
-      pending
-      user.follow(this_case)
-      expect(mail.body.encoded.gsub(/\s+/, '')).to include(I18n.t('notifier.confirmation_message')
-                                                              .gsub(/\s+/, ''))
-    end
-  end
 end


### PR DESCRIPTION
Per #3293, use Devise's `confirmable` module to confirm user emails.

* Remove our home-rolled `UserMailer.send_confirmation_email`
* Add :confirmable to User
* Add `unconfirmed_email` column to `users`, per Devise's demands
* Add tests on the confirmation email
* Preview the mailer at http://localhost:3000/rails/mailers/devise_mailer
