### PR TITLE
Explain why force_ssl setting should remain disabled

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -43,6 +43,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # This should remain disabled as Cloudflare handles the SSL Configuration [https://github.com/EBWiki/EBWiki/issues/1268]
   # config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information

--- a/config/environments/staging.rb
+++ b/config/environments/staging.rb
@@ -46,6 +46,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
+  # This should remain disabled as Cloudflare handles the SSL Configuration [https://github.com/EBWiki/EBWiki/issues/1268]
   config.force_ssl = false
 
   # Use the lowest log level to ensure availability of diagnostic information


### PR DESCRIPTION
In your PR did you:

  - [x] Include a description of the changes?
Cloudflare handles the SSL Configuration, I simply added a comment to explain this for anyone looking at the configuration files.
  - [x] Mention the issue the PR addresses?
Addresses https://github.com/EBWiki/EBWiki/issues/1268

  - [-] ~Include screenshots of any changes to the UI?~
  - [-] ~Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?~
  - [-] ~Add and/or update specs for your code?~
