### PR TITLE
[FIX] Add agency policy for destroy action

### DIFF
--- a/app/policies/agency_policy.rb
+++ b/app/policies/agency_policy.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Agency Policy
+class AgencyPolicy < ApplicationPolicy
+  def destroy?
+    user.admin?
+  end
+end

--- a/spec/policies/agency_policy_spec.rb
+++ b/spec/policies/agency_policy_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+describe AgencyPolicy do
+  subject { described_class }
+  let(:user) { FactoryBot.create(:user) }
+  let(:admin) { FactoryBot.create(:user, admin: true) }
+
+  permissions :destroy? do
+    it 'denies the ability to destroy agency if current user is not admin' do
+      expect(subject).not_to permit(user)
+    end
+
+    it 'permits the ability to destroy agency if current user is an admin' do
+      expect(subject).to permit(admin)
+    end
+  end
+end


### PR DESCRIPTION
Adds agency policy for `destroy` on `agency` to fix #3388 with spec

Issue reported in https://github.com/EBWiki/EBWiki/issues/3388

No UI changes required.
