### PR TITLE
Updates mailer spec to account for user names with symbols

### DIFF
--- a/spec/mailers/devise_mailer_spec.rb
+++ b/spec/mailers/devise_mailer_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Devise::Mailer, type: :mailer do
     end
 
     it 'addresses the user' do
-      expect(mail.body.encoded).to include(user.name)
+      expect(mail.body).to include(CGI.escapeHTML(user.name))
     end
 
     it 'is polite' do


### PR DESCRIPTION
This PR fixes an issue with the mailer spec where it failed to decode text properly when a name included a symbol like an apostraphe.

In your PR did you:

  - [X] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [X] Add and/or update specs for your code?
