### PR TITLE
Fix documentation relative links to files

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Welcome! Thanks for your interest in contributing to EBWiki.  This guide contain
 
 Please start with the Code of Conduct and then continue to the following documents.
 
-  1. [Code of Conduct](docs/CODE_OF_CONDUCT.md)
-  1. [Setting Up Your Development Environment](docs/SETUP_LOCALLY.md)
-  1. [Developing Code](docs/DEVELOPMENT.md)
-  1. TODO:[Submitting a Pull Request]()
+  1. [Code of Conduct](CODE_OF_CONDUCT.md)
+  1. [Setting Up Your Development Environment](SETUP_LOCALLY.md)
+  1. [Developing Code](DEVELOPMENT.md)
+  1. TODO: Submitting a Pull Request

--- a/docs/SETUP_LOCALLY.md
+++ b/docs/SETUP_LOCALLY.md
@@ -91,4 +91,4 @@ Open the following link in your browser:  http://localhost:3000
 ## Finish
 Now you're ready to start contributing!
 
-Next: [Development Documentation](docs/DEVELOPMENT.md).
+Next: [Development Documentation](DEVELOPMENT.md).

--- a/docs/SETUP_LOCALLY_FULLSTACK.md
+++ b/docs/SETUP_LOCALLY_FULLSTACK.md
@@ -1,6 +1,6 @@
 ```diff
 - NOTE: This document contains steps for the legacy method for setting up a local development environment.
-- Please refer to [the latest documentation](docs/SETUP_LOCALLY.md) for the current method using Docker.
+- Please refer to [the latest documentation](SETUP_LOCALLY.md) for the current method using Docker.
 ```
 
 This guide will explain the process of setting up a local development environment for EBWiki.  The guide assumes that you are using a Linux based command line prompt and either a Linux or Windows Operating System.  If you are using a different command line prompt and/or operating system, note that the order and exact nature of the installation and configuration may vary.

--- a/docs/SETUP_LOCALLY_FULLSTACK.md
+++ b/docs/SETUP_LOCALLY_FULLSTACK.md
@@ -31,7 +31,7 @@ To work on EBWiki locally you will need to have PostgreSQL and Elasticsearch run
 * [Redis](https://redis.io/)
 
 
-It is generally recommended that you have PostGreSQL and Elasticsearch start at bootup.
+It is generally recommended that you have PostGreSQL and Elasticsearch start on boot.
 
 ## App Configuration
 Using your command line, navigate to the location where you will store your local copy of the codebase.  Use the following command to clone a copy of the repo to your local environment:
@@ -95,7 +95,7 @@ Exit the console using the following command:
 ## Recaptcha & Local Development
 
 While in production we use [reCAPTCHA](https://www.google.com/recaptcha) to
-prevent bots from sigining up for this service, in order to simplify
+prevent bots from signing up for this service, in order to simplify
 development, reCAPTCHA is disabled in development by default.  In order
 to re-enable reCAPTCHA in development, remove the `config/initializers/recaptcha.rb`
 file or comment out the following line:


### PR DESCRIPTION
In your PR did you:

  - [X] Include a description of the changes?

Looking at the documentation to setup the environment I found that the relative links found inside `docs` folder were pointing to `docs/FILE` which broke them. This PRs changes that relative links to work properly, also it fixes some typos found.

  - [ ] Mention the issue the PR addresses?

There's no issue about this, I would he happy to create one if required.

  - [ ] Include screenshots of any changes to the UI?
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
