### PR TITLE
Remove tagging with GITHUB_SHA

### DIFF
--- a/.github/workflows/dockerhub.yml
+++ b/.github/workflows/dockerhub.yml
@@ -36,7 +36,6 @@ jobs:
           push: true
           tags: |
             ebwiki/ebwiki:latest
-            ebwiki/ebwiki:${GITHUB_SHA}
       -
         name: Image digest
         run: echo ${{ steps.docker_build.outputs.digest }}


### PR DESCRIPTION
In your PR did you:

  - [X] Include a description of the changes?
  - [ ] Mention the issue the PR addresses? N/A
  - [ ] Include screenshots of any changes to the UI? N/A
  - [ ] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)? N/A
  - [ ] Add and/or update specs for your code? N/A

This PR removes the tag using GITHUB_SHA when the newly built image is pushed to docker hub.
