### PR TITLE
Update webmock gem to 3.9.1 version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -78,7 +78,7 @@ group :test do
   gem 'selenium-webdriver', '~> 2.53.0'
   gem 'shoulda-matchers', '~> 4.4', '>= 4.4.1'
   gem 'vcr', '~> 3.0', '>= 3.0.3'
-  gem 'webmock'
+  gem 'webmock', '~>3.9', '>= 3.9.1'
 end
 
 gem 'bootstrap-sass', '>= 3.4.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -115,8 +115,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
     connection_pool (2.2.2)
-    crack (0.4.3)
-      safe_yaml (~> 1.0.0)
+    crack (0.4.4)
     crass (1.0.6)
     cucumber (3.1.2)
       builder (>= 2.1.2)
@@ -389,7 +388,7 @@ GEM
     haml (5.0.4)
       temple (>= 0.8.0)
       tilt
-    hashdiff (0.3.9)
+    hashdiff (1.0.1)
     hashie (3.6.0)
     heapy (0.2.0)
       thor
@@ -657,7 +656,6 @@ GEM
     ruby-statistics (2.1.2)
     ruby_dep (1.5.0)
     rubyzip (1.3.0)
-    safe_yaml (1.0.5)
     sass (3.7.4)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
@@ -746,10 +744,10 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webmock (3.5.1)
+    webmock (3.9.1)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
-      hashdiff
+      hashdiff (>= 0.4.0, < 2.0.0)
     webrobots (0.1.2)
     websocket (1.2.8)
     websocket-driver (0.6.5)
@@ -842,7 +840,7 @@ DEPENDENCIES
   uglifier (= 4.2)
   vcr (~> 3.0, >= 3.0.3)
   web-console (~> 3.7)
-  webmock
+  webmock (~> 3.9, >= 3.9.1)
 
 RUBY VERSION
    ruby 2.6.5p114


### PR DESCRIPTION
Update webmock gem from 3.5.1 to 3.9.1 version

closes #3779

In your PR did you:

  - [x] Include a description of the changes?
  - [x] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [x] Isolate any changes to gems (meaning that any new, updated, or removed gems and resulting code changes should be in their own PR)?
  - [ ] Add and/or update specs for your code?
