### PR TITLE
Rubocop: install specific rubocop version for CI

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
           echo $PATH
-          gem install --user-install rubocop
+          gem install --user-install rubocop -v=0.93.1
           rubocop --auto-correct-all --disable-uncorrectable
       - name: Check for changes
         run: |


### PR DESCRIPTION
**What**

This updates the CI configuration for Rubocop to install the same
version that is specified in `Gemfile.lock`.

**Why**

This should get the build passing. It's a quick fix. I think it might be
better to run `bundle` instead of installing `rubocop` directly. Caching
should reduce performance overhead.
