### PR TITLE
CI: specify rubocop version for build

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -13,7 +13,7 @@ jobs:
         run: |
           PATH="$(ruby -r rubygems -e 'puts Gem.user_dir')/bin:$PATH"
           echo $PATH
-          gem install --user-install rubocop
+          gem install --user-install rubocop -v=0.93.1
           rubocop --auto-correct-all --disable-uncorrectable
       - name: Check for changes
         run: |


### PR DESCRIPTION
**What**

Update the CI configuration for Rubocop to install the same version that
is specified in `Gemfile.lock`. I think it might be better to run
`bundle` instead of installing `rubocop` directly, but it will be good
to set up caching to reduce performance overhead.