### PR TITLE
CI: disable rollbar in dev mode

### DIFF
--- a/config/initializers/rollbar.rb
+++ b/config/initializers/rollbar.rb
@@ -10,8 +10,7 @@ Rollbar.configure do |config|
 
   config.environment = ENV['ROLLBAR_ENV']
 
-  # Here we'll disable in 'test':
-  config.enabled = false if Rails.env.test?
+  config.enabled = Rails.env.staging? || Rails.env.production?
 
   config.exception_level_filters['ActionController::RoutingError'] = 'ignore'
 


### PR DESCRIPTION
**What**

This makes it so that Rollbar only runs in staging and production mode.

**Notes**

Rollbar was already disabled for test mode, but errors were triggered on
CI, which makes me think the tests are running in dev mode instead of
test.
