### PR TITLE
CI: fix Sprockets issues

### DIFF
--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -1,0 +1,4 @@
+//= link_tree ../images
+//= link application.css
+//= link application.js
+//= link favicon/browserconfig.xml

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,3 +12,4 @@ Rails.application.config.assets.version = '1.0'
 # application.js, application.css, and all non-JS/CSS in app/assets folder are already added.
 # Rails.application.config.assets.precompile += %w( search.js )
 Rails.application.config.assets.precompile += %w[ckeditor/* markerclusterer chartkick]
+Rails.application.config.assets.export_concurrent = false


### PR DESCRIPTION
**What**

* Introduce `app/assets/config/manifest.js`. Sprockets was [recently
  upgraded][upgrade] to version 4, but [it now requires this file][file]
  to exist in order to determine which files to compile.
* Disable concurrent exports for Sprockets. It has a tendency to [cause
  segfaults][segfault] in Ruby, making builds (and deploys) super flaky.
  I've already seen it fail a few times working on getting the build
  passing.

[upgrade]: https://github.com/EBWiki/EBWiki/pull/3797
[file]: https://github.com/rails/sprockets/blob/master/UPGRADING.md#manifestjs
[segfault]: https://github.com/sass/sassc-ruby/issues/207
