### PR TITLE
CI: try removing call to `prewarm` script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,6 @@ build:
 run:
 	docker run --detach --rm --volume "$(shell pwd)":/usr/src/ebwiki \
 		--publish 3000:3000 --name ebwiki ebwiki/ebwiki
-	./dev_provisions/prewarm.sh
 
 updatedb:
 	docker exec -e PGPASSWORD=ebwiki ebwiki pg_restore --verbose --clean \


### PR DESCRIPTION
The CI build seems to be pretty slow and flaky. Most of the time when I
see it fail it is due to the `prewarm` script timing out. I'm wondering
if removing the call to the script will speed things up at all.
