### PR TITLE
Fixes seeds file and downgrades sprockets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -168,3 +168,5 @@ gem 'recaptcha'
 group :production do
   gem 'cloudflare-rails', '~> 0.6'
 end
+
+gem 'sprockets', '3.7.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -735,7 +735,7 @@ GEM
       builder (~> 3.0)
     social-share-button (1.2.3)
       coffee-rails
-    sprockets (4.0.2)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.2)
@@ -871,6 +871,7 @@ DEPENDENCIES
   simplecov (~> 0.19.0)
   sitemap_generator (~> 6.1)
   social-share-button
+  sprockets (= 3.7.2)
   turbolinks (~> 5.2)
   twitter (~> 7.0)
   uglifier (= 4.2)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -163,175 +163,32 @@ if Ethnicity.count.zero?
 end
 
 if User.count.zero?
-    puts 'Creating Users...'
+  puts 'Creating Users...'
 
-    users = [
-      { name: 'John Doe',
-        email: 'jdoe@example.com',
-        password: 'password',
-        password_confirmation: 'password',
-        admin: true },
-      { name: 'Jane Smith',
-        email: 'jsmith@example.com',
-        password: 'password',
-        password_confirmation: 'password' },
-      { name: 'Jan Alleman',
-        email: 'jalleman@example.com',
-        password: 'password',
-        password_confirmation: 'password' },
-      {name: 'Zhang San',
-        email: 'szhang@example.com',
-        password: 'password',
-        password_confirmation: 'password' }
-    ]
-
-    users.each do |user|
-      User.create(user)
-    end
+  # All users have the password 'password'
+  FactoryBot.create(:user, name: 'John Doe', email: 'jdoe@example.com', admin: true)
+  FactoryBot.create(:user, name: 'Jane Smith', email: 'jsmith@example.com')
+  FactoryBot.create(:user, name: 'Jan Alleman', email: 'jalleman@example.com')
+  FactoryBot.create(:user, name: 'Zhang San', email: 'szhang@example.com')
 end
+
 if Case.count.zero?
   puts 'Creating Cases...'
-  cases = [
-    { title: 'Sven Svensson',
-      date: '01/10/2017',
-      subjects_attributes: { '0' => { name: 'Sven Svensson',
-                                      age: '25'
-                                    }
-                           },
-      city: 'Houston',
-      state: State.find_by(name: 'Texas'),
-      overview: 'a',
-      blurb: 'Sven Svensson',
-      summary: 'Added a case' },
-
-    { title: 'Janez Novak',
-      date: '02/10/2017',
-      subjects_attributes: { '0' => { name: 'Janez Novak',
-                                      age: '26'
-                                    }
-                           },
-      city: 'Little Rock',
-      state: State.find_by(name: 'Arkansas'),
-      overview: 'a',
-      blurb: 'Janez Novak',
-      summary: 'Added a case' },
-
-    { title: 'Janina Kowalska',
-      date: '01/12/2011',
-      subjects_attributes: { '0' => { name: 'Janina Kowalska',
-                                      age: '35'
-                                    }
-                           },
-      city: 'Boulder',
-      state: State.find_by(name: 'Colorado'),
-      overview: 'a',
-      blurb: 'Janina Kowalska',
-      summary: 'Added a case' },
-
-    { title: 'Kari Holm',
-      date: '11/05/2017',
-      subjects_attributes: { '0' => { name: 'Kari Holm',
-                                      age: '20'
-                                    }
-                           },
-      city: 'Pensacola',
-      state_id: State.find_by(name: 'Florida'),
-      overview: 'a',
-      blurb: 'Kari Holm',
-      summary: 'Added a case' },
-
-    { title: 'Jonas Petraitis',
-      date: '31/10/2017',
-      subjects_attributes: { '0' => { name: 'Jonas Petraitis',
-                                      age: '56'
-                                    }
-                           },
-      city: 'Boise',
-      state_id: State.find_by(name: 'Idaho'),
-      overview: 'a',
-      blurb: 'Jonas Petraitis',
-      summary: 'Added a case' },
-
-    { title: 'Manku Thimman',
-      date: '17/03/1997',
-      subjects_attributes: { '0' => { name: 'Manku Thimma',
-                                      age: '33'
-                                    }
-                           },
-      city: 'Gary',
-      state_id: State.find_by(name: 'Indiana'),
-      overview: 'a',
-      blurb: 'Manku Thimman',
-      summary: 'Added a case' },
-
-    { title: 'Mario Rossi',
-      date: '21/11/2004',
-      subjects_attributes: { '0' => { name: 'Mario Rossi',
-                                      age: '31'
-                                    }
-                           },
-      city: 'Louisville',
-      state: State.find_by(name: 'Kentucky'),
-      overview: 'a',
-      blurb: 'Mario Rossi',
-      summary: 'Added a case' },
-
-    { title: 'Max Mustermann',
-      date: '11/05/2014',
-      subjects_attributes: { '0' => { name: 'Max Mustermann',
-                                      age: '25'
-                                    }
-                           },
-      city: 'Amherst',
-      state: State.find_by(name: 'Massachusetts'),
-      overview: 'a',
-      blurb: 'Max Mustermann',
-      summary: 'Added a case' },
-
-    { title: 'Chichiko Bendeliani',
-      date: '09/07/2009',
-      subjects_attributes: { '0' => { name: 'Chichiko Bendeliani',
-                                      age: '40'
-                                    }
-                           },
-      city: 'St. Louis',
-      state:  State.find_by(name: 'Missouri'),
-      overview: 'a',
-      blurb: 'Chichiko Bendeliani',
-      summary: 'Added a case' },
-
-    { title: 'Sally Housecoat',
-      date: '01/01/2001',
-      subjects_attributes: { '0' => { name: 'Sally Housecoat',
-                                      age: '39'
-                                    }
-                           },
-      city: 'Houston',
-      state_id: State.find_by(name: 'Texas'),
-      overview: 'a',
-      blurb: 'Sally Housecoat',
-      summary: 'Added a case' }
-  ]
-
-  cases.each do |this_case|
-    Rails.logger.info "Adding case #{this_case['title']}"
-    Case.create(this_case)
-  end
+  states = State.limit(10).pluck(:id)
+  FactoryBot.create(:case, title: 'Sven Svensson', date: Date.new(2017, 1, 10), city: 'Houston', state_id: states[0])
+  FactoryBot.create(:case, title: 'Janez Novak', date: Date.new(2017, 2, 10), city: 'Little Rock', state_id: states[1])
+  FactoryBot.create(:case, title: 'Janina Kowalska', date: Date.new(2011, 1, 12), city: 'Boulder', state_id: states[2])
+  FactoryBot.create(:case, title: 'Kari Holm', date: Date.new(2017, 11, 5), city: 'Pensacola', state_id: states[3])
+  FactoryBot.create(:case, title: 'Jonas Petraitis', date: Date.new(2017, 10, 31), city: 'Boise', state_id: states[4])
+  FactoryBot.create(:case, title: 'Manku Thimman', date: Date.new(1997, 3, 17), city: 'Gary', state_id: states[5])
+  FactoryBot.create(:case, title: 'Mario Rossi', date: Date.new(2004, 11, 21), city: 'Louisville', state_id: states[6])
+  FactoryBot.create(:case, title: 'Max Mustermann', date: Date.new(2004, 10, 15), city: 'Amherst', state_id: states[7])
+  FactoryBot.create(:case, title: 'Chichiko Bendeliani', date: Date.new(2007, 9, 7), city: 'St. Louis', state_id: states[8])
+  FactoryBot.create(:case, title: 'Sally Housecoat', date: Date.new(2001, 1, 1), city: 'Houston', state_id: states[9])
 end
 
 if Agency.count.zero?
   puts 'Creating Agencies...'
-
-  agencies = [
-    { name: 'City of Houston Police Department',
-      city: 'Houston',
-      state:  State.where(name: 'Texas').first },
-    { name: 'City of Beaumont Police Department',
-      city: 'Beaumont',
-      state:  State.where(name: 'Texas').first }
-  ]
-
-  agencies.each do |agency|
-    Agency.create(agency)
-  end
+  FactoryBot.create(:agency, name: 'City of Houston Police Department', city: 'Houston')
+  FactoryBot.create(:agency, name: 'City of Beaumont Police Department', city: 'Beaumont')
 end

--- a/docs/DEVELOPMENT.md
+++ b/docs/DEVELOPMENT.md
@@ -5,7 +5,6 @@ Welcome to our developer documentation for EBWiki!  Thank you for committing to 
 # Table of Contents
 * [General Timeline for Contributing to EBWiki](#general-timeline-for-contributing-to-ebwiki)
 * [Getting EBWiki Up and Running Locally](#getting-ebwiki-up-and-running-locally)
-* [Restoring Local Database from Production Backup](#restoring-local-database-from-production-backup)
 * [Third-Party Services](#third-party-services)
 
 ## General Timeline for Contributing to EBWiki
@@ -32,19 +31,17 @@ If everything looks great on staging, then we'll push the code to production wit
 ## Getting EBWiki Up and Running Locally
 
 There are a number of guides available for running EBWiki in your local environment:
-* [Running locally using a text editor and terminal](SETUP_LOCALLY.md)
+* [Running locally using a docker container](SETUP_LOCALLY.md)
+* [Running locally using a text editor and terminal](SETUP_LOCALLY_FULLSTACK.md)
 * [Running in a Cloud9 workspace](https://github.com/EBWiki/EBWiki/wiki/Running-EB-Wiki-development-environment-on-Cloud9-(WIP))
 
 ## Restoring Local Database from Production Backup
 
-The EBWiki repo has a `db/seeds.rb` file that you can use to add some basic data to your local database for development purposes.  However, there are times when you want your local database to have data similar to what you'd see in production (e.g, when working on analytics or search).  To address that, the repo also contains a recent backup of the production database, named `latest.dump`.  To restore the backup dump into your local database, use the following command:
-
-```
-pg_restore --verbose --clean --no-acl --no-owner -p 5432 -h localhost -U blackops -d blackops_development latest.dump
+The EBWiki repo has a `db/seeds.rb` file that you can use to add some basic data to your local database for development purposes.  However, there may be times when you want your local database to have data similar to what you'd see in production (e.g, when working on analytics or search).  In that case, please leave a comment stating your need on your ticket and mention Rachel Green or Mark Nyon.
 ```
 
 ## Third-Party Services
 * Elasticsearch for searching cases
-* Postgres 9.4 or higher
+* Postgres 11 or higher
 * Redis
 * Sumologic


### PR DESCRIPTION
Fixes the seeds file and removes the production database backup.  Updates the docs accordingly.  Also downgrades Sprockets due to seg fault issues.

More detail: Since the seeds file is in better shape, I went ahead and removed the production database backup.  We can find another spot for that, but I wasn't a huge fan of having that in the repo, since we could potentially expose personal information to anyone that clones the repo.  To that end, I included a note that if someone does need something closer to the prod database to work on a ticket to let us know.

I also downgraded Sprockets from 4 to 3.7.2 - Sprockets 4 is causing consistent segfaults when run on Linux distros with a kernel version of 5+, [as described here](https://github.com/rails/sprockets/issues/633).  Once that issue is addressed, we'll be able to just remove the line specifying the version in the Gemfile; everything else is still configured to work for 4.

In your PR did you:

  - [X] Include a description of the changes?
  - [ ] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Add and/or update specs for your code?
  - [ ] Update the release tasks script to reflect tasks that should run when deploying to staging or production?
