### PR TITLE
3789 change fog to fog aws

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -90,7 +90,6 @@ gem 'devise', '4.7.3'
 gem 'simple_form', '5.0'
 
 # for aws cloud storage
-gem 'fog', '2.2'
 # photo resizing
 gem 'mini_magick', '~> 4.10'
 # file upload solution

--- a/Gemfile
+++ b/Gemfile
@@ -90,6 +90,7 @@ gem 'devise', '4.7.3'
 gem 'simple_form', '5.0'
 
 # for aws cloud storage
+gem 'fog-aws', '~> 3.10'
 # photo resizing
 gem 'mini_magick', '~> 4.10'
 # file upload solution

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -13,7 +13,6 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (2.3.6)
     actioncable (5.1.7)
       actionpack (= 5.1.7)
       nio4r (~> 2.0)
@@ -65,9 +64,6 @@ GEM
       tzinfo (~> 1.1)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
-    aliyun-sdk (0.8.0)
-      nokogiri (~> 1.6)
-      rest-client (~> 2.0)
     arel (8.0.0)
     ast (2.4.2)
     autoprefixer-rails (10.2.4.0)
@@ -157,7 +153,6 @@ GEM
     database_cleaner-active_record (1.8.0)
       activerecord
       database_cleaner (~> 1.8.0)
-    declarative (0.0.20)
     derailed_benchmarks (1.8.1)
       benchmark-ips (~> 2)
       get_process_mem (~> 0)
@@ -182,7 +177,6 @@ GEM
     dotenv-rails (2.7.6)
       dotenv (= 2.7.6)
       railties (>= 3.2)
-    dry-inflector (0.2.0)
     elasticsearch (7.12.0)
       elasticsearch-api (= 7.12.0)
       elasticsearch-transport (= 7.12.0)
@@ -217,168 +211,6 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
-    fission (0.5.0)
-      CFPropertyList (~> 2.2)
-    fog (2.2.0)
-      fog-aliyun (>= 0.1.0)
-      fog-atmos
-      fog-aws (>= 0.6.0)
-      fog-brightbox (~> 0.4)
-      fog-cloudatcost (~> 0.4)
-      fog-cloudstack (~> 0.1.0)
-      fog-core (~> 2.1)
-      fog-digitalocean (>= 0.3.0)
-      fog-dnsimple (~> 2.1)
-      fog-dynect (~> 0.0.2)
-      fog-ecloud (~> 0.1)
-      fog-google (~> 1.0)
-      fog-internet-archive
-      fog-json
-      fog-local
-      fog-openstack
-      fog-ovirt
-      fog-powerdns (>= 0.1.1)
-      fog-profitbricks
-      fog-rackspace
-      fog-radosgw (>= 0.0.2)
-      fog-riakcs
-      fog-sakuracloud (>= 0.0.4)
-      fog-serverlove
-      fog-softlayer
-      fog-storm_on_demand
-      fog-terremark
-      fog-vmfusion
-      fog-voxel
-      fog-vsphere (>= 0.4.0)
-      fog-xenserver
-      fog-xml (~> 0.1.1)
-      ipaddress (~> 0.5)
-      json (~> 2.0)
-    fog-aliyun (0.3.19)
-      aliyun-sdk (~> 0.8.0)
-      fog-core
-      fog-json
-      ipaddress (~> 0.8)
-      xml-simple (~> 1.1)
-    fog-atmos (0.1.0)
-      fog-core
-      fog-xml
-    fog-aws (3.10.0)
-      fog-core (~> 2.1)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
-      ipaddress (~> 0.8)
-    fog-brightbox (0.16.1)
-      dry-inflector
-      fog-core
-      fog-json
-      mime-types
-    fog-cloudatcost (0.4.0)
-      fog-core
-      fog-json
-      ipaddress
-    fog-cloudstack (0.1.0)
-      fog-core (~> 2.1)
-      fog-json (~> 1.1)
-      fog-xml (~> 0.1)
-    fog-core (2.1.0)
-      builder
-      excon (~> 0.58)
-      formatador (~> 0.2)
-      mime-types
-    fog-digitalocean (0.4.0)
-      fog-core
-      fog-json
-      fog-xml
-      ipaddress (>= 0.5)
-    fog-dnsimple (2.1.0)
-      fog-core (>= 1.38, < 3)
-      fog-json
-    fog-dynect (0.0.3)
-      fog-core
-      fog-json
-      fog-xml
-    fog-ecloud (0.3.0)
-      fog-core
-      fog-xml
-    fog-google (1.12.1)
-      fog-core (<= 2.1.0)
-      fog-json (~> 1.2)
-      fog-xml (~> 0.1.0)
-      google-api-client (>= 0.44.2, < 0.51)
-      google-cloud-env (~> 1.2)
-    fog-internet-archive (0.0.2)
-      fog-core
-      fog-json
-      fog-xml
-    fog-json (1.2.0)
-      fog-core
-      multi_json (~> 1.10)
-    fog-local (0.6.0)
-      fog-core (>= 1.27, < 3.0)
-    fog-openstack (1.0.11)
-      fog-core (~> 2.1)
-      fog-json (>= 1.0)
-      ipaddress (>= 0.8)
-    fog-ovirt (2.0.1)
-      activesupport
-      fog-core
-      fog-json
-      fog-xml
-      ovirt-engine-sdk (>= 4.3.1)
-    fog-powerdns (0.2.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-profitbricks (0.0.5)
-      fog-core
-      fog-xml
-      nokogiri
-    fog-rackspace (0.1.6)
-      fog-core (>= 1.35)
-      fog-json (>= 1.0)
-      fog-xml (>= 0.1)
-      ipaddress (>= 0.8)
-    fog-radosgw (0.0.5)
-      fog-core (>= 1.21.0)
-      fog-json
-      fog-xml (>= 0.0.1)
-    fog-riakcs (0.1.0)
-      fog-core
-      fog-json
-      fog-xml
-    fog-sakuracloud (1.7.5)
-      fog-core
-      fog-json
-    fog-serverlove (0.1.2)
-      fog-core
-      fog-json
-    fog-softlayer (1.1.4)
-      fog-core
-      fog-json
-    fog-storm_on_demand (0.1.1)
-      fog-core
-      fog-json
-    fog-terremark (0.1.0)
-      fog-core
-      fog-xml
-    fog-vmfusion (0.1.0)
-      fission
-      fog-core
-    fog-voxel (0.1.0)
-      fog-core
-      fog-xml
-    fog-vsphere (3.5.0)
-      fog-core
-      rbvmomi (>= 1.9, < 3)
-    fog-xenserver (1.0.0)
-      fog-core
-      fog-xml
-      xmlrpc
-    fog-xml (0.1.3)
-      fog-core
-      nokogiri (>= 1.5.11, < 2.0.0)
-    formatador (0.2.5)
     friendly_id (5.4.2)
       activerecord (>= 4.0.0)
     galerts (1.1.3)
@@ -392,24 +224,6 @@ GEM
       multi_json (>= 1.11.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
-    google-api-client (0.50.0)
-      addressable (~> 2.5, >= 2.5.1)
-      googleauth (~> 0.9)
-      httpclient (>= 2.8.1, < 3.0)
-      mini_mime (~> 1.0)
-      representable (~> 3.0)
-      retriable (>= 2.0, < 4.0)
-      rexml
-      signet (~> 0.12)
-    google-cloud-env (1.5.0)
-      faraday (>= 0.17.3, < 2.0)
-    googleauth (0.16.1)
-      faraday (>= 0.17.3, < 2.0)
-      jwt (>= 1.4, < 3.0)
-      memoist (~> 0.16)
-      multi_json (~> 1.11)
-      os (>= 0.9, < 2.0)
-      signet (~> 0.14)
     groupdate (5.2.2)
       activesupport (>= 5)
     haml (5.2.1)
@@ -427,7 +241,6 @@ GEM
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
       http-parser (~> 1.2.0)
-    http-accept (1.7.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
@@ -437,14 +250,12 @@ GEM
     httparty (0.18.1)
       mime-types (~> 3.0)
       multi_xml (>= 0.5.2)
-    httpclient (2.8.3)
     i18n (1.8.10)
       concurrent-ruby (~> 1.0)
     image_optimizer (1.8.0)
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
-    ipaddress (0.8.3)
     jb (0.7.1)
       multi_json
     jquery-rails (4.4.0)
@@ -454,7 +265,6 @@ GEM
     jquery-ui-rails (6.0.1)
       railties (>= 3.2.16)
     json (2.5.1)
-    jwt (2.2.2)
     kaminari (1.2.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.2.1)
@@ -494,7 +304,6 @@ GEM
       rubyntlm (~> 0.6, >= 0.6.3)
       webrick (~> 1.7)
       webrobots (~> 0.1.2)
-    memoist (0.16.2)
     memoizable (0.4.2)
       thread_safe (~> 0.3, >= 0.3.1)
     memory_profiler (0.9.14)
@@ -520,17 +329,12 @@ GEM
     net-http-digest_auth (1.4.1)
     net-http-persistent (4.0.1)
       connection_pool (~> 2.2)
-    netrc (0.11.0)
     newrelic_rpm (7.0.0)
     nio4r (2.5.7)
     nokogiri (1.11.5)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
-    optimist (3.0.1)
     orm_adapter (0.5.0)
-    os (1.1.1)
-    ovirt-engine-sdk (4.4.1)
-      json (>= 1, < 3)
     paper_trail (10.3.1)
       activerecord (>= 4.2)
       request_store (~> 1.1)
@@ -605,11 +409,6 @@ GEM
       thor (>= 0.18.1, < 2.0)
     rainbow (3.0.0)
     rake (13.0.3)
-    rbvmomi (2.4.1)
-      builder (~> 3.0)
-      json (>= 1.8)
-      nokogiri (~> 1.5)
-      optimist (~> 3.0)
     recaptcha (5.8.0)
       json
     redis (4.2.5)
@@ -633,21 +432,11 @@ GEM
       redis (>= 4, < 5)
     regexp_parser (2.1.1)
     remotipart (1.4.4)
-    representable (3.1.1)
-      declarative (< 0.1.0)
-      trailblazer-option (>= 0.1.1, < 0.2.0)
-      uber (< 0.2.0)
     request_store (1.5.0)
       rack (>= 1.4)
     responders (3.0.1)
       actionpack (>= 5.0)
       railties (>= 5.0)
-    rest-client (2.1.0)
-      http-accept (>= 1.7.0, < 2.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 4.0)
-      netrc (~> 0.8)
-    retriable (3.1.2)
     rexml (3.2.5)
     rollbar (3.1.2)
     rspec-core (3.10.1)
@@ -711,11 +500,6 @@ GEM
       websocket (~> 1.0)
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
-    signet (0.15.0)
-      addressable (~> 2.3)
-      faraday (>= 0.17.3, < 2.0)
-      jwt (>= 1.5, < 3.0)
-      multi_json (~> 1.10)
     simple_form (5.0.0)
       actionpack (>= 5.0)
       activemodel (>= 5.0)
@@ -740,7 +524,6 @@ GEM
     thor (1.1.0)
     thread_safe (0.3.6)
     tilt (2.0.10)
-    trailblazer-option (0.1.1)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -757,7 +540,6 @@ GEM
       simple_oauth (~> 0.3.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    uber (0.1.0)
     uglifier (4.2.0)
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
@@ -783,9 +565,6 @@ GEM
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
-    xml-simple (1.1.8)
-    xmlrpc (0.3.2)
-      webrick
     xpath (3.2.0)
       nokogiri (~> 1.8)
 
@@ -814,7 +593,6 @@ DEPENDENCIES
   dotenv-rails (~> 2.7)
   factory_bot_rails (~> 6.1)
   faker (~> 2.14.0)
-  fog (= 2.2)
   friendly_id (~> 5.2)
   galerts (~> 1.1)
   geocoder

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -211,6 +211,23 @@ GEM
     ffi-compiler (1.0.1)
       ffi (>= 1.0.0)
       rake
+    fog-aws (3.10.0)
+      fog-core (~> 2.1)
+      fog-json (~> 1.1)
+      fog-xml (~> 0.1)
+      ipaddress (~> 0.8)
+    fog-core (2.2.4)
+      builder
+      excon (~> 0.71)
+      formatador (~> 0.2)
+      mime-types
+    fog-json (1.2.0)
+      fog-core
+      multi_json (~> 1.10)
+    fog-xml (0.1.3)
+      fog-core
+      nokogiri (>= 1.5.11, < 2.0.0)
+    formatador (0.3.0)
     friendly_id (5.4.2)
       activerecord (>= 4.0.0)
     galerts (1.1.3)
@@ -256,6 +273,7 @@ GEM
     image_processing (1.12.1)
       mini_magick (>= 4.9.5, < 5)
       ruby-vips (>= 2.0.17, < 3)
+    ipaddress (0.8.3)
     jb (0.7.1)
       multi_json
     jquery-rails (4.4.0)
@@ -593,6 +611,7 @@ DEPENDENCIES
   dotenv-rails (~> 2.7)
   factory_bot_rails (~> 6.1)
   faker (~> 2.14.0)
+  fog-aws (~> 3.10)
   friendly_id (~> 5.2)
   galerts (~> 1.1)
   geocoder

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -3,7 +3,16 @@
 CarrierWave.configure do |config|
   if Rails.env.development?
     config.storage = :file
+  elsif Rails.env.test?
+    config.storage = :file
+    config.enable_processing = false
   else
-    config.enable_processing = false if Rails.env.test?
+    config.storage = :fog
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
+      aws_secret_access_key: ENV['AWS_SECRET_KEY_ID']
+    }
+    config.fog_directory = ENV['S3_BUCKET']
   end
 end

--- a/config/initializers/carrier_wave.rb
+++ b/config/initializers/carrier_wave.rb
@@ -4,15 +4,6 @@ CarrierWave.configure do |config|
   if Rails.env.development?
     config.storage = :file
   else
-    config.fog_credentials = {
-      provider: 'AWS',
-      aws_access_key_id: ENV['AWS_ACCESS_KEY_ID'],
-      aws_secret_access_key: ENV['AWS_SECRET_KEY_ID']
-      # region: ENV['S3_REGION'] # Change this for different AWS region. Default is 'us-east-1'
-    }
-    config.storage = :fog
-    config.fog_directory = ENV['S3_BUCKET']
-
     config.enable_processing = false if Rails.env.test?
   end
 end

--- a/spec/models/case_spec.rb
+++ b/spec/models/case_spec.rb
@@ -36,70 +36,52 @@ RSpec.describe Case do
 end
 
 describe 'versioning', versioning: true do
-  it 'starts versioning when a new case is created' do
-    this_case = FactoryBot.create(:case)
-    expect(this_case.versions.size).to eq 1
-    expect(this_case.versions.map(&:event)).to eq %w[create]
-  end
 
   it 'adds a version when the title is changed' do
     this_case = FactoryBot.create(:case)
-    this_case.update_attribute(:title, 'A New Title')
-    expect(this_case.versions.size).to eq 2
-    expect(this_case.versions.map(&:event)).to eq %w[create update]
+    old_title = this_case.title
+    this_case.update!(title: 'A New Title')
+    expect(this_case).to have_a_version_with title: old_title
   end
 
   it 'adds a version when the overview is changed' do
     this_case = FactoryBot.create(:case)
-    this_case.update_attribute(:overview, 'An Old Case')
-    expect(this_case.versions.size).to eq 2
-    expect(this_case.versions.map(&:event)).to eq %w[create update]
+    old_overview = this_case.overview
+    this_case.update!(overview: 'An Old Case')
+    expect(this_case).to have_a_version_with overview: old_overview
   end
 
   it 'adds a version when the date is changed' do
     this_case = FactoryBot.create(:case)
-    this_case.update_attribute(:date, (Time.current - 1.day))
-    expect(this_case.versions.size).to eq 2
-    expect(this_case.versions.map(&:event)).to eq %w[create update]
+    old_date = this_case.date
+    this_case.update!(date: Date.current.yesterday)
+    expect(this_case).to have_a_version_with date: old_date
   end
 
   it 'adds a version when the city is changed' do
     this_case = FactoryBot.create(:case)
-    this_case.update_attribute(:city, 'Buffalo')
-    expect(this_case.versions.size).to eq 2
-    expect(this_case.versions.map(&:event)).to eq %w[create update]
-  end
-
-  it 'adds a version when the avatar is changed' do
-    this_case = FactoryBot.create(:case)
-    this_case.update_attribute(:avatar, 'new_avatar')
-    expect(this_case.versions.size).to eq 2
-    expect(this_case.versions.map(&:event)).to eq %w[create update]
+    old_city = this_case.city
+    this_case.update!(city: 'Buffalo')
+    expect(this_case).to have_a_version_with city: old_city
   end
 
   it 'adds a version when the video url is changed' do
     this_case = FactoryBot.create(:case)
-    this_case.update_attribute(:video_url, 'new_video.com')
-    expect(this_case.versions.size).to eq 2
-    expect(this_case.versions.map(&:event)).to eq %w[create update]
+    old_video_url = this_case.video_url
+    this_case.update!(video_url: 'new_video.com')
+    expect(this_case).to have_a_version_with video_url: old_video_url
   end
 
   it 'adds a version when the slug is changed' do
     this_case = FactoryBot.create(:case)
-    this_case.update_attribute(:slug, 'joel-osteen')
-    expect(this_case.versions.size).to eq 2
-    expect(this_case.versions.map(&:event)).to eq %w[create update]
-  end
-
-  it 'does not add a version when the attribute is the same' do
-    this_case = FactoryBot.create(:case, title: 'The Title')
-    this_case.update_attribute(:title, 'The Title')
-    expect(this_case.versions.size).to eq 1
+    old_slug = this_case.slug
+    this_case.update!(slug: 'joel-osteen')
+    expect(this_case).to have_a_version_with slug: old_slug
   end
 
   it 'copies the this_case.summary attribute to version.comment' do
     this_case = FactoryBot.create(:case, title: 'The Title')
-    this_case.update_attributes(title: 'The Title has changed', summary: 'fixed the title')
+    this_case.update!(title: 'The Title has changed', summary: 'fixed the title')
     expect(this_case.versions.last.comment).to eq 'fixed the title'
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -149,12 +149,3 @@ Shoulda::Matchers.configure do |config|
     with.library :action_controller
   end
 end
-
-# Configure rspec to use fog mocks
-Fog.mock!
-service = Fog::Storage.new({
-                             provider: 'AWS',
-                             aws_access_key_id: 'fake_access_key_id',
-                             aws_secret_access_key: 'fake_secret_access_key'
-                           })
-service.directories.create(key: 'testbucket')


### PR DESCRIPTION
Changes `fog` gem to `fog-aws` for use of S3 with Carrierwave.  Also includes updates of specs for versioning functionality for cases.  Addresses #3789 

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [X] Add and/or update specs for your code?
  - [ ] Update the release tasks script to reflect tasks that should run when deploying to staging or production?
