### PR TITLE
Removes the updatedb Makefile target; adds the searchkick and reindex…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,6 @@ run:
 		--publish 3000:3000 --name ebwiki ebwiki/ebwiki
 	./dev_provisions/prewarm.sh
 
-updatedb:
-	docker exec -e PGPASSWORD=ebwiki ebwiki pg_restore --verbose --clean \
-		--no-acl --no-owner -p 5432 -h localhost -U blackops \
-		-d blackops_development /usr/src/ebwiki/latest.dump || true
-
 logs:
 	docker logs --timestamps --follow ebwiki
 
@@ -26,6 +21,11 @@ clean: stop
 
 test:
 	./dev_provisions/run_tests.sh
+
+searchkick reindex_all:
+	@echo "## Please note that searchkick requires the container to be running and"
+	@echo "## takes a while to complete"
+	docker exec ebwiki bash -c 'source dev_provisions/environment.sh && rake searchkick:reindex:all'
 
 rspec:
 	@echo "## Please note that rspec requires the container to be running and"


### PR DESCRIPTION
This PR addresses Issue #3702 
This PR updates the Makefile with the following:
- Removes the `updatedb` target.  The `latest.dump` file is no longer present in the repo which causes this target to fail.  removing it for now.
- Add the `searchkick` and `reindex_all` targets.  These targets run the rake task to reindex the search after the container boots up.

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [N/A] Include screenshots of any changes to the UI?
  - [N/A] Add and/or update specs for your code?
  - [N/A] Update the release tasks script to reflect tasks that should run when deploying to staging or production?