### PR TITLE
Renames cause_of_death_name to cause_of_death

### DIFF
--- a/app/controllers/cases_controller.rb
+++ b/app/controllers/cases_controller.rb
@@ -110,7 +110,7 @@ class CasesController < ApplicationController # rubocop:todo Metrics/ClassLength
       :litigation,
       :community_action,
       :agency_id,
-      :cause_of_death_name,
+      :cause_of_death,
       :date,
       :state_id,
       :city,

--- a/app/models/case.rb
+++ b/app/models/case.rb
@@ -6,7 +6,7 @@ class Case < ApplicationRecord
 
   MAX_BLURB_CHARACTERS = 500
 
-  enum cause_of_death_name: {
+  enum cause_of_death: {
     beating: 'beating',
     bombing: 'bombing',
     chemical_agents_or_weapons: 'chemical_agents_or_weapons',
@@ -138,33 +138,32 @@ end
 #
 # Table name: cases
 #
-#  id                  :integer          not null, primary key
-#  address             :string
-#  age                 :integer
-#  avatar              :string
-#  blurb               :text
-#  cause_of_death_name :enum
-#  city                :string           not null
-#  community_action    :text
-#  country             :string
-#  date                :date
-#  default_avatar_url  :string
-#  follows_count       :integer          default(0), not null
-#  latitude            :float
-#  litigation          :text
-#  longitude           :float
-#  overview            :text             not null
-#  remove_avatar       :boolean
-#  slug                :string
-#  state               :string
-#  summary             :text             not null
-#  title               :string           not null
-#  video_url           :string
-#  zipcode             :string
-#  created_at          :datetime         not null
-#  updated_at          :datetime         not null
-#  cause_of_death_id   :integer
-#  state_id            :integer
+#  id                 :integer          not null, primary key
+#  address            :string
+#  age                :integer
+#  avatar             :string
+#  blurb              :text
+#  cause_of_death     :enum
+#  city               :string           not null
+#  community_action   :text
+#  country            :string
+#  date               :date
+#  default_avatar_url :string
+#  follows_count      :integer          default(0), not null
+#  latitude           :float
+#  litigation         :text
+#  longitude          :float
+#  overview           :text             not null
+#  remove_avatar      :boolean
+#  slug               :string
+#  state              :string
+#  summary            :text             not null
+#  title              :string           not null
+#  video_url          :string
+#  zipcode            :string
+#  created_at         :datetime         not null
+#  updated_at         :datetime         not null
+#  state_id           :integer
 #
 # Indexes
 #

--- a/app/views/cases/_form.html.erb
+++ b/app/views/cases/_form.html.erb
@@ -37,7 +37,7 @@
 				<h4>Add a YouTube or Vimeo video url relating to the case:</h4>
 				<%= f.input :video_url %>
 				<h4>Cause of death:</h4>
-				<%= f.input :cause_of_death_name, collection: [:choking, :shooting, :beating, :taser, :vehicular, :medical_neglect, :response_to_medical_emergency, :suicide, :chemical_agents_or_weapons, :stabbing, :drowning], label: false, required: true %>
+				<%= f.input :cause_of_death, collection: [:choking, :shooting, :beating, :taser, :vehicular, :medical_neglect, :response_to_medical_emergency, :suicide, :chemical_agents_or_weapons, :stabbing, :drowning], label: false, required: true %>
 	    </div>
 		</fieldset>
 	</div>

--- a/app/views/cases/show.html.erb
+++ b/app/views/cases/show.html.erb
@@ -51,7 +51,7 @@
           <% end %>
         </p>
       <% end %>
-      <p class="h5">Cause of death: <b><%= @this_case.cause_of_death_name.presence&.titleize || 'Not Yet Known' %></b></p>
+      <p class="h5">Cause of death: <b><%= @this_case.cause_of_death.presence&.titleize || 'Not Yet Known' %></b></p>
       <br />
       <p>
         <% if current_user %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -20,7 +20,7 @@ en:
           university: 'University'
           commercial: 'Commercial'
       case:
-        cause_of_death_name:
+        cause_of_death:
           beating: 'Beating'
           bombing: 'Bombing'
           chemical_agents_or_weapons: 'Chemical Agents or Weapons'

--- a/db/migrate/20220109194513_rename_cause_of_death_name_column.rb
+++ b/db/migrate/20220109194513_rename_cause_of_death_name_column.rb
@@ -1,0 +1,5 @@
+class RenameCauseOfDeathNameColumn < ActiveRecord::Migration[5.2]
+  def change
+    rename_column(:cases, :cause_of_death_name, :cause_of_death)
+  end
+end

--- a/db/migrate/20220109195551_remove_cause_of_death_id_from_cases.rb
+++ b/db/migrate/20220109195551_remove_cause_of_death_id_from_cases.rb
@@ -1,0 +1,5 @@
+class RemoveCauseOfDeathIdFromCases < ActiveRecord::Migration[5.2]
+  def change
+    remove_column(:cases, :cause_of_death_id, :integer)
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -228,7 +228,6 @@ CREATE TABLE public.cases (
     title character varying NOT NULL,
     created_at timestamp without time zone NOT NULL,
     updated_at timestamp without time zone NOT NULL,
-    cause_of_death_id integer,
     date date,
     state_id integer,
     city character varying NOT NULL,
@@ -250,7 +249,7 @@ CREATE TABLE public.cases (
     follows_count integer DEFAULT 0 NOT NULL,
     default_avatar_url character varying,
     blurb text,
-    cause_of_death_name public.cause_of_death
+    cause_of_death public.cause_of_death
 );
 
 
@@ -1781,6 +1780,8 @@ INSERT INTO "schema_migrations" (version) VALUES
 ('20211013144648'),
 ('20211018164958'),
 ('20211026091305'),
-('20211108220639');
+('20211108220639'),
+('20220109194513'),
+('20220109195551');
 
 

--- a/spec/requests/conversations_spec.rb
+++ b/spec/requests/conversations_spec.rb
@@ -3,12 +3,12 @@
 require 'rails_helper'
 
 RSpec.describe 'Conversations', type: :request do
-  let!(:user) { create(:user) }
-  let!(:another_user) { create(:user) }
+  let(:user) { create(:user) }
+  let(:another_user) { create(:user) }
 
   before { allow_any_instance_of(Mailboxer::MailDispatcher).to receive(:call) }
 
-  let(:conversation) { another_user.send_message(user, Faker::Lorem.paragraph, Faker::Lorem.sentence).conversation }
+  let!(:conversation) { another_user.send_message(user, Faker::Lorem.paragraph, Faker::Lorem.sentence).conversation }
 
   describe 'GET /conversations/new' do
     context 'when authenticated' do


### PR DESCRIPTION
Renames all instances of cause_of_death_name to cause_of_death.  Also removes unneeded cause_of_death_id column from cases table.  Addresses issue #4067 

In your PR did you:

  - [X] Include a description of the changes?
  - [X] Mention the issue the PR addresses?
  - [ ] Include screenshots of any changes to the UI?
  - [ ] Add and/or update specs for your code?
  - [ ] Update the release tasks script to reflect tasks that should run when deploying to staging or production?
