### PR TITLE
Bump config.load_defaults from 7.2 to 8.0

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,9 +11,9 @@ Bundler.require(*Rails.groups)
 
 module EBWiki
   class Application < Rails::Application
-    # Initialize configuration defaults for Rails 7.2
+    # Initialize configuration defaults for Rails 8.0
     # Incrementally upgrading: 7.0 → 7.1 → 7.2 → 8.0 → 8.1
-    config.load_defaults 7.2
+    config.load_defaults 8.0
 
     # Use structure.sql instead of schema.rb for database schema
     config.active_record.schema_format = :sql

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,9 +11,9 @@ Bundler.require(*Rails.groups)
 
 module EBWiki
   class Application < Rails::Application
-    # Initialize configuration defaults for Rails 7.1
+    # Initialize configuration defaults for Rails 7.2
     # Incrementally upgrading: 7.0 → 7.1 → 7.2 → 8.0 → 8.1
-    config.load_defaults 7.1
+    config.load_defaults 7.2
 
     # Use structure.sql instead of schema.rb for database schema
     config.active_record.schema_format = :sql


### PR DESCRIPTION
## Summary

Advances `config.load_defaults` from `7.2` to `8.0` as part of the incremental Rails 8.1 upgrade path.

**Notable 8.0 defaults enabled:**
- `action_dispatch.show_exceptions = :rescuable` (was `:all`)
- `action_controller.raise_on_missing_callback_actions = true`
- `active_record.validate_migration_timestamps = true`

## Test results

Full RSpec suite: **254 examples, 0 failures, 4 pending** (same pre-existing pending specs, no regressions).

## Next steps

- Phase 3: `load_defaults 8.0 → 8.1` (final step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Enables Rails 8.0 framework defaults app-wide, which can subtly change exception handling, controller behavior, and ActiveRecord validation semantics. Risk is moderate because it’s a global configuration switch even though the code diff is small.
> 
> **Overview**
> Updates `config.load_defaults` in `config/application.rb` from Rails `7.1` to `8.0` (and adjusts the comment accordingly), enabling Rails 8.0 default framework behaviors across the application.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cf4790bb2f35789f3a5018a92dc2143c42244f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Rails framework version from 7.1 to 8.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->